### PR TITLE
docs: refresh README after Phase 2-4 completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cargo install --path crates/analyzer-cli
 
 ### Via agent-sh plugins
 
-If you use the [git-map](https://github.com/agent-sh/git-map) plugin, the binary is downloaded automatically on first use. No manual install needed.
+If you use the [repo-intel](https://github.com/agent-sh/repo-intel) plugin, the binary is downloaded automatically on first use. No manual install needed.
 
 ## Quick start
 
@@ -92,7 +92,7 @@ agent-analyzer repo-intel init /path/to/repo > repo-intel.json
 ### Incremental update
 
 ```bash
-agent-analyzer repo-intel update /path/to/repo --map-file repo-intel.json > git-map-updated.json
+agent-analyzer repo-intel update /path/to/repo --map-file repo-intel.json > repo-intel-updated.json
 ```
 
 ### Check status
@@ -160,12 +160,11 @@ Signatures are loaded from an embedded JSON registry (`ai_signatures.json`). To 
 - **Merge commits are skipped** - only non-merge commits are analyzed, which matches how most tools attribute changes
 - **Shallow clones** - work but produce incomplete history; the output includes a `shallow: true` flag
 - **Large monorepos** - initial scan scales linearly with commit count; use `--max-commits` to bound the scan
-- **Stub crates** - `repo-map`, `collectors`, and `sync-check` subcommands print "not yet implemented" (Phases 2-4)
 
 ## Development
 
 ```bash
-cargo test                            # 77 tests across all crates
+cargo test                            # 146 tests across all crates
 cargo clippy -- -D warnings           # lint
 cargo fmt --check                     # format check
 cargo build --release                 # optimized binary (LTO + stripped)
@@ -179,13 +178,10 @@ This binary is consumed by JS plugins in the agent-sh ecosystem via a binary res
 - Binary location: `~/.agent-sh/bin/agent-analyzer[.exe]`
 - No manual install - lazy download on first use
 
-Current consumers:
-- [git-map](https://github.com/agent-sh/git-map) plugin (JS wrapper for `/git-map` command)
-
-Planned consumers (Phases 2-4):
-- `repo-map` plugin (replace ast-grep subprocess)
-- `agent-core/lib/collectors/` (replace JS implementations)
-- `sync-docs` plugin (replace JS analysis)
+Consumers:
+- [repo-intel](https://github.com/agent-sh/repo-intel) plugin (unified static analysis wrapper - git history, AST symbols, project metadata, doc-code sync)
+- `agent-core/lib/collectors/` (uses `collect` CLI for project metadata)
+- [sync-docs](https://github.com/agent-sh/sync-docs) plugin (uses `sync-check` CLI for doc-code cross-references)
 
 ## Contributing
 

--- a/crates/analyzer-collectors/Cargo.toml
+++ b/crates/analyzer-collectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analyzer-collectors"
-description = "Project data gathering for agent-analyzer (Phase 3 stub)"
+description = "Project metadata gathering for agent-analyzer"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/analyzer-repo-map/Cargo.toml
+++ b/crates/analyzer-repo-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analyzer-repo-map"
-description = "AST-based symbol mapping for agent-analyzer (Phase 2 stub)"
+description = "AST-based symbol mapping for agent-analyzer"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/analyzer-sync-check/Cargo.toml
+++ b/crates/analyzer-sync-check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analyzer-sync-check"
-description = "Doc-code sync analysis for agent-analyzer (Phase 4 stub)"
+description = "Doc-code sync analysis for agent-analyzer"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary
- Dropped the "stubs" label from Phase 2-4 crates - those crates are complete
- Renamed git-map references to repo-intel (plugin rename)
- Updated test count from 77 to 146
- Rewrote the Consumers section with the current consumer list

## Why
Detected during workspace-wide repo-intel doc-drift scan.

## Test plan
- [ ] CI passes
- [ ] Counts match plugin repos

Docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates to README (plugin naming, examples, and integration notes) with no runtime or API changes.
> 
> **Overview**
> Updates `README.md` to reflect the `repo-intel` plugin rename and current Phase 2–4 completion: fixes example output filenames, removes the “stub crates” limitation note, updates the stated test count (77→146), and rewrites the Integration/Consumers section to list current consumers and their responsibilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df0c621d6d60ac39422be41cd2a0cc7693c8c850. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->