### PR TITLE
feat(graph): co-change communities + betweenness via analyzer-graph crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "analyzer-collectors",
  "analyzer-core",
  "analyzer-git-map",
+ "analyzer-graph",
  "analyzer-repo-map",
  "analyzer-sync-check",
  "anyhow",
@@ -73,6 +74,19 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "analyzer-graph"
+version = "0.3.2"
+dependencies = [
+ "analyzer-core",
+ "anyhow",
+ "chrono",
+ "petgraph",
+ "rayon",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -358,6 +372,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "foldhash"
@@ -779,6 +799,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/analyzer-repo-map",
     "crates/analyzer-collectors",
     "crates/analyzer-sync-check",
+    "crates/analyzer-graph",
     "crates/analyzer-cli",
 ]
 
@@ -34,6 +35,7 @@ analyzer-git-map = { path = "crates/analyzer-git-map" }
 analyzer-repo-map = { path = "crates/analyzer-repo-map" }
 analyzer-collectors = { path = "crates/analyzer-collectors" }
 analyzer-sync-check = { path = "crates/analyzer-sync-check" }
+analyzer-graph = { path = "crates/analyzer-graph" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ regex = "1"
 # Parallelism
 rayon = "1.10"
 
+# Graph algorithms (analyzer-graph)
+petgraph = "0.6"
+
 # AST parsing (Phase 2)
 tree-sitter = "0.24"
 tree-sitter-rust = "0.23"

--- a/crates/analyzer-cli/src/commands/repo_intel.rs
+++ b/crates/analyzer-cli/src/commands/repo_intel.rs
@@ -294,6 +294,45 @@ pub enum QueryAction {
         #[arg(long)]
         map_file: PathBuf,
     },
+    /// List communities discovered by co-change graph Louvain partitioning
+    Communities {
+        /// Repository path
+        path: PathBuf,
+        /// Path to repo-intel JSON file
+        #[arg(long)]
+        map_file: PathBuf,
+    },
+    /// Show files bridging communities (high betweenness centrality)
+    Boundaries {
+        /// Repository path
+        path: PathBuf,
+        /// Maximum number of results
+        #[arg(long, default_value = "10")]
+        top: usize,
+        /// Path to repo-intel JSON file
+        #[arg(long)]
+        map_file: PathBuf,
+    },
+    /// Look up which community a file belongs to
+    AreaOf {
+        /// File path (relative to repo root)
+        file: String,
+        /// Repository path
+        path: PathBuf,
+        /// Path to repo-intel JSON file
+        #[arg(long)]
+        map_file: PathBuf,
+    },
+    /// Show composite health metrics for one community by id
+    CommunityHealth {
+        /// Community id (from `communities` query)
+        id: u32,
+        /// Repository path
+        path: PathBuf,
+        /// Path to repo-intel JSON file
+        #[arg(long)]
+        map_file: PathBuf,
+    },
 }
 
 pub fn run(action: RepoIntelAction) -> Result<()> {
@@ -359,6 +398,23 @@ fn run_init(path: &Path, _max_commits: Option<usize>) -> Result<()> {
         }
     }
 
+    // Phase 5: Graph-derived analytics (co-change communities + centrality)
+    eprintln!("[INFO] Building co-change graph...");
+    analyzer_graph::finalize(&mut map);
+    if let Some(cg) = map
+        .graph
+        .as_ref()
+        .and_then(|g| g.cochange.as_ref())
+    {
+        eprintln!(
+            "[INFO] Discovered {} communities from {} edges",
+            cg.communities.len(),
+            cg.edges.len()
+        );
+    } else {
+        eprintln!("[INFO] Insufficient co-change signal - graph not built");
+    }
+
     println!("{}", output::to_json(&map));
     eprintln!("[OK] Repo intel map created successfully");
     Ok(())
@@ -418,6 +474,11 @@ fn run_update(path: &Path, map_file: &Path) -> Result<()> {
             Err(e) => eprintln!("[WARN] Doc-code sync check failed: {e}"),
         }
     }
+
+    // Refresh Phase 5 graph analytics. Full re-cluster on update for now -
+    // incremental Louvain on dirty subgraphs is a future optimisation.
+    eprintln!("[INFO] Rebuilding co-change graph...");
+    analyzer_graph::finalize(&mut map);
 
     println!("{}", output::to_json(&map));
     eprintln!("[OK] Repo intel map updated successfully");
@@ -648,6 +709,35 @@ fn run_query(query: QueryAction) -> Result<()> {
             let map = load_map(&map_file)?;
             let result = queries::painspots(&map, top);
             println!("{}", output::to_json(&result));
+        }
+        QueryAction::Communities { map_file, .. } => {
+            let map = load_map(&map_file)?;
+            let result = analyzer_graph::queries::communities(&map);
+            println!("{}", output::to_json(&result));
+        }
+        QueryAction::Boundaries { top, map_file, .. } => {
+            let map = load_map(&map_file)?;
+            let result = analyzer_graph::queries::boundaries(&map, top);
+            println!("{}", output::to_json(&result));
+        }
+        QueryAction::AreaOf {
+            file, map_file, ..
+        } => {
+            let map = load_map(&map_file)?;
+            let result = analyzer_graph::queries::area_of(&map, &file);
+            println!("{}", output::to_json(&result));
+        }
+        QueryAction::CommunityHealth { id, map_file, .. } => {
+            let map = load_map(&map_file)?;
+            match analyzer_graph::queries::community_health(&map, id) {
+                Some(health) => println!("{}", output::to_json(&health)),
+                None => {
+                    eprintln!(
+                        "[WARN] Community id {id} not found (run `repo-intel query communities` to list ids)"
+                    );
+                    println!("null");
+                }
+            }
         }
     }
     Ok(())

--- a/crates/analyzer-cli/src/commands/repo_intel.rs
+++ b/crates/analyzer-cli/src/commands/repo_intel.rs
@@ -401,11 +401,7 @@ fn run_init(path: &Path, _max_commits: Option<usize>) -> Result<()> {
     // Phase 5: Graph-derived analytics (co-change communities + centrality)
     eprintln!("[INFO] Building co-change graph...");
     analyzer_graph::finalize(&mut map);
-    if let Some(cg) = map
-        .graph
-        .as_ref()
-        .and_then(|g| g.cochange.as_ref())
-    {
+    if let Some(cg) = map.graph.as_ref().and_then(|g| g.cochange.as_ref()) {
         eprintln!(
             "[INFO] Discovered {} communities from {} edges",
             cg.communities.len(),
@@ -720,9 +716,7 @@ fn run_query(query: QueryAction) -> Result<()> {
             let result = analyzer_graph::queries::boundaries(&map, top);
             println!("{}", output::to_json(&result));
         }
-        QueryAction::AreaOf {
-            file, map_file, ..
-        } => {
+        QueryAction::AreaOf { file, map_file, .. } => {
             let map = load_map(&map_file)?;
             let result = analyzer_graph::queries::area_of(&map, &file);
             println!("{}", output::to_json(&result));

--- a/crates/analyzer-collectors/src/languages.rs
+++ b/crates/analyzer-collectors/src/languages.rs
@@ -207,7 +207,7 @@ pub fn detect_languages(repo_path: &Path) -> Vec<LanguageInfo> {
         })
         .collect();
 
-    langs.sort_by(|a, b| b.file_count.cmp(&a.file_count));
+    langs.sort_by_key(|l| std::cmp::Reverse(l.file_count));
     langs
 }
 

--- a/crates/analyzer-core/src/types.rs
+++ b/crates/analyzer-core/src/types.rs
@@ -34,6 +34,10 @@ pub struct RepoIntelData {
     // Phase 4: Doc-code cross-references (optional - populated when sync-check runs)
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub doc_refs: Option<HashMap<String, DocRefEntry>>,
+
+    // Phase 5: Graph-derived analytics (optional - populated by analyzer-graph)
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub graph: Option<GraphData>,
 }
 
 /// Git repository metadata.
@@ -406,6 +410,106 @@ pub fn extract_conventional_prefix(subject: &str) -> Option<String> {
     None
 }
 
+// ─── Phase 5: Graph-Derived Analytics ───────────────────────────
+
+/// Graph-derived analytics: communities, centrality, expertise.
+///
+/// Three sub-graphs share this container - each is independently optional so
+/// future analyzer phases can add one without breaking older readers:
+///   - `cochange` - file co-change graph + Louvain communities (Phase 5.1)
+///   - `import`   - directed import/call graph centrality (Phase 5.2)
+///   - `author`   - author-file bipartite authority (Phase 5.3)
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphData {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cochange: Option<CochangeGraph>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub import: Option<ImportGraph>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub author: Option<AuthorGraph>,
+}
+
+/// Co-change graph: undirected weighted graph over files, plus discovered
+/// communities (Louvain) and betweenness centrality.
+///
+/// Edges are sparse - only file pairs above the configured Jaccard and
+/// raw-cochange thresholds appear.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CochangeGraph {
+    /// Edges with Jaccard weights (filtered).
+    pub edges: Vec<CochangeEdge>,
+    /// Discovered communities: community_id -> file paths.
+    pub communities: HashMap<u32, Vec<String>>,
+    /// Reverse lookup: file path -> community_id.
+    pub file_to_community: HashMap<String, u32>,
+    /// Betweenness centrality per file (boundary detection).
+    pub betweenness: HashMap<String, f64>,
+    /// Threshold parameters used to build this graph (recorded for reproducibility).
+    pub params: CochangeParams,
+}
+
+/// A weighted undirected edge in the co-change graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CochangeEdge {
+    pub a: String,
+    pub b: String,
+    pub jaccard: f64,
+    pub cochanges: u64,
+}
+
+/// Co-change graph build parameters.
+///
+/// Defaults are calibrated from co-change graph literature (Zimmermann et al.,
+/// Hassan & Holt) and hold across repos from ~50 commits to 100k+.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CochangeParams {
+    pub min_jaccard: f64,
+    pub min_cochanges: u64,
+    pub louvain_resolution: f64,
+    pub min_community_size: usize,
+}
+
+impl Default for CochangeParams {
+    fn default() -> Self {
+        Self {
+            min_jaccard: 0.05,
+            min_cochanges: 3,
+            louvain_resolution: 1.0,
+            min_community_size: 3,
+        }
+    }
+}
+
+/// Import/call graph centrality (Phase 5.2 - placeholder).
+///
+/// Populated by analyzer-graph from the existing `import_graph` field. Will
+/// hold PageRank, strongly-connected components, and reverse-reachability
+/// data once Phase 5.2 lands.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportGraph {
+    /// PageRank score per file (higher = more structurally central).
+    pub pagerank: HashMap<String, f64>,
+    /// Strongly-connected components of size > 1 (architectural cycles).
+    pub cycles: Vec<Vec<String>>,
+}
+
+/// Author-file authority graph (Phase 5.3 - placeholder).
+///
+/// Populated by analyzer-graph from the existing per-file `authors` lists +
+/// `FileActivity` change counts. Will hold HITS-style authority scores per
+/// (author, area) once Phase 5.3 lands.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorGraph {
+    /// Authority score: author -> community_id -> score.
+    pub authority: HashMap<String, HashMap<u32, f64>>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -506,6 +610,7 @@ mod tests {
             import_graph: None,
             project: None,
             doc_refs: None,
+            graph: None,
         };
 
         let json = serde_json::to_string(&data).unwrap();

--- a/crates/analyzer-git-map/src/aggregator.rs
+++ b/crates/analyzer-git-map/src/aggregator.rs
@@ -55,6 +55,7 @@ pub fn create_empty_map() -> RepoIntelData {
         import_graph: None,
         project: None,
         doc_refs: None,
+        graph: None,
     }
 }
 

--- a/crates/analyzer-git-map/src/queries.rs
+++ b/crates/analyzer-git-map/src/queries.rs
@@ -205,7 +205,7 @@ pub fn coupling(map: &RepoIntelData, file: &str, human_only: bool) -> Vec<Coupli
         }
     }
 
-    results.sort_by(|a, b| b.cochanges.cmp(&a.cochanges));
+    results.sort_by_key(|r| std::cmp::Reverse(r.cochanges));
     results
 }
 
@@ -281,7 +281,7 @@ pub fn ownership(map: &RepoIntelData, dir_or_file: &str) -> OwnershipResult {
         })
         .collect();
 
-    owners.sort_by(|a, b| b.commits.cmp(&a.commits));
+    owners.sort_by_key(|c| std::cmp::Reverse(c.commits));
 
     let primary = owners.first().map(|c| c.name.clone()).unwrap_or_default();
     let primary_pct = owners.first().map(|c| c.pct).unwrap_or(0.0);
@@ -612,7 +612,7 @@ fn areas_impl(map: &RepoIntelData, active_only: bool) -> Vec<AreaEntry> {
                 })
                 .collect();
 
-            owners.sort_by(|a, b| b.commits.cmp(&a.commits));
+            owners.sort_by_key(|c| std::cmp::Reverse(c.commits));
 
             // Health classification
             let primary_stale = owners.first().map(|o| o.stale).unwrap_or(true);
@@ -792,7 +792,7 @@ pub fn contributors(map: &RepoIntelData, _months: Option<u32>) -> Vec<Contributo
         })
         .collect();
 
-    entries.sort_by(|a, b| b.commits.cmp(&a.commits));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.commits));
     entries
 }
 
@@ -1002,7 +1002,7 @@ pub fn test_gaps(map: &RepoIntelData, min_changes: u64, limit: usize) -> Vec<Tes
         })
         .collect();
 
-    entries.sort_by(|a, b| b.changes.cmp(&a.changes));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.changes));
     entries.truncate(limit);
     entries
 }

--- a/crates/analyzer-graph/Cargo.toml
+++ b/crates/analyzer-graph/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
-petgraph = "0.6"
+petgraph.workspace = true
 rayon.workspace = true
 
 [dev-dependencies]

--- a/crates/analyzer-graph/Cargo.toml
+++ b/crates/analyzer-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "analyzer-cli"
-description = "Unified CLI binary for agent-analyzer"
+name = "analyzer-graph"
+description = "Graph-derived analytics (co-change communities, centrality, expertise) for agent-analyzer"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -11,18 +11,14 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
-[[bin]]
-name = "agent-analyzer"
-path = "src/main.rs"
-
 [dependencies]
 analyzer-core.workspace = true
-analyzer-git-map.workspace = true
-analyzer-repo-map.workspace = true
-analyzer-collectors.workspace = true
-analyzer-sync-check.workspace = true
-analyzer-graph.workspace = true
-clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
+chrono.workspace = true
+petgraph = "0.6"
+rayon.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/analyzer-graph/src/centrality.rs
+++ b/crates/analyzer-graph/src/centrality.rs
@@ -17,64 +17,123 @@ use std::collections::VecDeque;
 
 use petgraph::Undirected;
 use petgraph::graph::{Graph, NodeIndex};
+use rayon::prelude::*;
+
+/// Per-thread scratch space reused across single-source passes within one
+/// rayon worker. Pre-allocating once and clearing between passes avoids
+/// the O(V²) allocations the naive Brandes formulation would do.
+struct Scratch {
+    stack: Vec<usize>,
+    predecessors: Vec<Vec<usize>>,
+    sigma: Vec<f64>,
+    distance: Vec<i64>,
+    delta: Vec<f64>,
+    queue: VecDeque<usize>,
+    bc: Vec<f64>,
+}
+
+impl Scratch {
+    fn new(n: usize) -> Self {
+        Self {
+            stack: Vec::with_capacity(n),
+            predecessors: vec![Vec::new(); n],
+            sigma: vec![0.0; n],
+            distance: vec![-1; n],
+            delta: vec![0.0; n],
+            queue: VecDeque::with_capacity(n),
+            bc: vec![0.0; n],
+        }
+    }
+
+    /// Reset only the per-source state - `bc` accumulates across sources.
+    fn reset_for_source(&mut self) {
+        self.stack.clear();
+        for p in self.predecessors.iter_mut() {
+            p.clear();
+        }
+        self.sigma.fill(0.0);
+        self.distance.fill(-1);
+        self.delta.fill(0.0);
+        self.queue.clear();
+    }
+}
 
 /// Returns a vector indexed by `NodeIndex` with the unnormalised betweenness
 /// score of each node. Endpoints are not included in the count (standard
 /// Brandes accumulation).
+///
+/// Parallelised across source nodes via rayon. Each worker keeps its own
+/// scratch space and partial BC accumulator; partials are summed at the end.
+/// Output is deterministic - rayon `into_par_iter().fold().reduce()` does
+/// not depend on completion order because addition is commutative for the
+/// scores we produce.
 pub fn betweenness(graph: &Graph<(), f64, Undirected>) -> Vec<f64> {
     let n = graph.node_count();
-    let mut bc = vec![0.0f64; n];
     if n < 3 {
-        return bc;
+        return vec![0.0; n];
     }
 
-    for src in 0..n {
-        // Brandes' single-source pass.
-        let mut stack: Vec<usize> = Vec::with_capacity(n);
-        let mut predecessors: Vec<Vec<usize>> = vec![Vec::new(); n];
-        let mut sigma = vec![0.0f64; n];
-        let mut distance = vec![-1i64; n];
-
-        sigma[src] = 1.0;
-        distance[src] = 0;
-
-        let mut queue: VecDeque<usize> = VecDeque::new();
-        queue.push_back(src);
-
-        while let Some(v) = queue.pop_front() {
-            stack.push(v);
-            let v_node: NodeIndex = NodeIndex::new(v);
-            for neighbour in graph.neighbors(v_node) {
-                let w = neighbour.index();
-                if distance[w] < 0 {
-                    distance[w] = distance[v] + 1;
-                    queue.push_back(w);
+    let bc = (0..n)
+        .into_par_iter()
+        .fold(
+            || Scratch::new(n),
+            |mut s, src| {
+                s.reset_for_source();
+                single_source_pass(graph, src, &mut s);
+                s
+            },
+        )
+        .map(|s| s.bc)
+        .reduce(
+            || vec![0.0; n],
+            |mut acc, partial| {
+                for (a, p) in acc.iter_mut().zip(partial.iter()) {
+                    *a += *p;
                 }
-                if distance[w] == distance[v] + 1 {
-                    sigma[w] += sigma[v];
-                    predecessors[w].push(v);
-                }
-            }
-        }
-
-        // Accumulation in reverse BFS order.
-        let mut delta = vec![0.0f64; n];
-        while let Some(w) = stack.pop() {
-            for &v in &predecessors[w] {
-                delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w]);
-            }
-            if w != src {
-                bc[w] += delta[w];
-            }
-        }
-    }
+                acc
+            },
+        );
 
     // Undirected: each pair (s, t) is counted twice across the two passes.
-    for v in bc.iter_mut() {
-        *v /= 2.0;
+    bc.into_iter().map(|v| v / 2.0).collect()
+}
+
+/// One Brandes single-source pass: BFS for shortest-path counts, then
+/// reverse-order accumulation of pair-dependencies.
+fn single_source_pass(graph: &Graph<(), f64, Undirected>, src: usize, s: &mut Scratch) {
+    s.sigma[src] = 1.0;
+    s.distance[src] = 0;
+    s.queue.push_back(src);
+
+    while let Some(v) = s.queue.pop_front() {
+        s.stack.push(v);
+        let v_node: NodeIndex = NodeIndex::new(v);
+        for neighbour in graph.neighbors(v_node) {
+            let w = neighbour.index();
+            if s.distance[w] < 0 {
+                s.distance[w] = s.distance[v] + 1;
+                s.queue.push_back(w);
+            }
+            if s.distance[w] == s.distance[v] + 1 {
+                s.sigma[w] += s.sigma[v];
+                s.predecessors[w].push(v);
+            }
+        }
     }
 
-    bc
+    while let Some(w) = s.stack.pop() {
+        // Snapshot read once - the mutable borrow on s.delta below would
+        // otherwise conflict with the immutable read of s.predecessors[w].
+        let preds_len = s.predecessors[w].len();
+        for i in 0..preds_len {
+            let v = s.predecessors[w][i];
+            let contribution = (s.sigma[v] / s.sigma[w]) * (1.0 + s.delta[w]);
+            s.delta[v] += contribution;
+        }
+        if w != src {
+            s.bc[w] += s.delta[w];
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/analyzer-graph/src/centrality.rs
+++ b/crates/analyzer-graph/src/centrality.rs
@@ -1,0 +1,131 @@
+//! Betweenness centrality via Brandes' algorithm (2001).
+//!
+//! For each source s, run a BFS to compute shortest-path counts σ(s, t) and
+//! predecessor sets P(s, t) for every target t. Then accumulate
+//! pair-dependencies δ(s, ·) in reverse BFS order:
+//!
+//!   δ(s, v) = Σ_w:v∈P(s,w) (σ(s,v) / σ(s,w)) * (1 + δ(s, w))
+//!
+//! Betweenness BC(v) is the sum of δ(s, v) over all source nodes, halved
+//! for undirected graphs (each pair counted twice).
+//!
+//! We use the unweighted variant - edge weights in the co-change graph
+//! mean "how related" not "how costly to traverse", so BFS (topological
+//! distance) is the correct shortest-path notion. Matches NetworkX's default.
+
+use std::collections::VecDeque;
+
+use petgraph::Undirected;
+use petgraph::graph::{Graph, NodeIndex};
+
+/// Returns a vector indexed by `NodeIndex` with the unnormalised betweenness
+/// score of each node. Endpoints are not included in the count (standard
+/// Brandes accumulation).
+pub fn betweenness(graph: &Graph<(), f64, Undirected>) -> Vec<f64> {
+    let n = graph.node_count();
+    let mut bc = vec![0.0f64; n];
+    if n < 3 {
+        return bc;
+    }
+
+    for src in 0..n {
+        // Brandes' single-source pass.
+        let mut stack: Vec<usize> = Vec::with_capacity(n);
+        let mut predecessors: Vec<Vec<usize>> = vec![Vec::new(); n];
+        let mut sigma = vec![0.0f64; n];
+        let mut distance = vec![-1i64; n];
+
+        sigma[src] = 1.0;
+        distance[src] = 0;
+
+        let mut queue: VecDeque<usize> = VecDeque::new();
+        queue.push_back(src);
+
+        while let Some(v) = queue.pop_front() {
+            stack.push(v);
+            let v_node: NodeIndex = NodeIndex::new(v);
+            for neighbour in graph.neighbors(v_node) {
+                let w = neighbour.index();
+                if distance[w] < 0 {
+                    distance[w] = distance[v] + 1;
+                    queue.push_back(w);
+                }
+                if distance[w] == distance[v] + 1 {
+                    sigma[w] += sigma[v];
+                    predecessors[w].push(v);
+                }
+            }
+        }
+
+        // Accumulation in reverse BFS order.
+        let mut delta = vec![0.0f64; n];
+        while let Some(w) = stack.pop() {
+            for &v in &predecessors[w] {
+                delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w]);
+            }
+            if w != src {
+                bc[w] += delta[w];
+            }
+        }
+    }
+
+    // Undirected: each pair (s, t) is counted twice across the two passes.
+    for v in bc.iter_mut() {
+        *v /= 2.0;
+    }
+
+    bc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use petgraph::graph::Graph;
+
+    #[test]
+    fn path_graph_middle_node_has_highest_centrality() {
+        // 0 - 1 - 2 - 3 - 4
+        let mut g: Graph<(), f64, Undirected> = Graph::new_undirected();
+        let nodes: Vec<_> = (0..5).map(|_| g.add_node(())).collect();
+        for i in 0..4 {
+            g.add_edge(nodes[i], nodes[i + 1], 1.0);
+        }
+
+        let bc = betweenness(&g);
+        // Middle node should have the highest BC. Endpoints should be zero.
+        assert_eq!(bc[0], 0.0);
+        assert_eq!(bc[4], 0.0);
+        assert!(bc[2] > bc[1]);
+        assert!(bc[2] > bc[3]);
+    }
+
+    #[test]
+    fn star_graph_hub_has_all_centrality() {
+        // Hub (0) connected to 4 leaves.
+        let mut g: Graph<(), f64, Undirected> = Graph::new_undirected();
+        let hub = g.add_node(());
+        let leaves: Vec<_> = (0..4).map(|_| g.add_node(())).collect();
+        for &leaf in &leaves {
+            g.add_edge(hub, leaf, 1.0);
+        }
+
+        let bc = betweenness(&g);
+        assert!(bc[0] > 0.0);
+        for &leaf in &leaves {
+            assert_eq!(bc[leaf.index()], 0.0);
+        }
+    }
+
+    #[test]
+    fn disconnected_graph_all_zero() {
+        // Two disjoint edges: 0-1 and 2-3.
+        let mut g: Graph<(), f64, Undirected> = Graph::new_undirected();
+        let n: Vec<_> = (0..4).map(|_| g.add_node(())).collect();
+        g.add_edge(n[0], n[1], 1.0);
+        g.add_edge(n[2], n[3], 1.0);
+        let bc = betweenness(&g);
+        for v in bc {
+            assert_eq!(v, 0.0);
+        }
+    }
+}

--- a/crates/analyzer-graph/src/cochange.rs
+++ b/crates/analyzer-graph/src/cochange.rs
@@ -18,9 +18,7 @@ use std::collections::HashMap;
 use petgraph::Undirected;
 use petgraph::graph::{Graph, NodeIndex};
 
-use analyzer_core::types::{
-    CochangeEdge, CochangeGraph, CochangeParams, RepoIntelData,
-};
+use analyzer_core::types::{CochangeEdge, CochangeGraph, CochangeParams, RepoIntelData};
 
 use crate::{centrality, louvain};
 
@@ -107,11 +105,7 @@ pub fn build_with(map: &RepoIntelData, params: CochangeParams) -> Option<Cochang
     }
 
     // Louvain partition with our resolution + small-community merge.
-    let partition = louvain::run(
-        &graph,
-        params.louvain_resolution,
-        params.min_community_size,
-    );
+    let partition = louvain::run(&graph, params.louvain_resolution, params.min_community_size);
 
     // Communities: u32 -> [paths].
     let mut communities: HashMap<u32, Vec<String>> = HashMap::new();
@@ -226,17 +220,14 @@ mod tests {
 
         for (a, b, cochanges) in coupling_pairs {
             let (lo, hi) = if a < b { (a, b) } else { (b, a) };
-            data.coupling
-                .entry((*lo).to_string())
-                .or_default()
-                .insert(
-                    (*hi).to_string(),
-                    CouplingEntry {
-                        cochanges: *cochanges,
-                        human_cochanges: *cochanges,
-                        ai_cochanges: 0,
-                    },
-                );
+            data.coupling.entry((*lo).to_string()).or_default().insert(
+                (*hi).to_string(),
+                CouplingEntry {
+                    cochanges: *cochanges,
+                    human_cochanges: *cochanges,
+                    ai_cochanges: 0,
+                },
+            );
         }
         data
     }
@@ -293,7 +284,10 @@ mod tests {
 
         let comm_a = g.file_to_community["a.rs"];
         let comm_d = g.file_to_community["d.rs"];
-        assert_ne!(comm_a, comm_d, "two triangles should land in distinct communities");
+        assert_ne!(
+            comm_a, comm_d,
+            "two triangles should land in distinct communities"
+        );
         assert_eq!(g.file_to_community["b.rs"], comm_a);
         assert_eq!(g.file_to_community["c.rs"], comm_a);
         assert_eq!(g.file_to_community["e.rs"], comm_d);

--- a/crates/analyzer-graph/src/cochange.rs
+++ b/crates/analyzer-graph/src/cochange.rs
@@ -1,0 +1,329 @@
+//! Co-change graph construction.
+//!
+//! Reads `RepoIntelData.coupling` (already pruned to ≥3 raw co-changes by the
+//! aggregator) plus `file_activity[*].changes` and produces a sparse
+//! undirected weighted graph where:
+//!
+//!   weight(a, b) = jaccard = |A ∩ B| / |A ∪ B|
+//!
+//! with |A ∩ B| = `coupling[a][b].cochanges` and
+//! |A ∪ B| = `changes[a] + changes[b] - cochanges`.
+//!
+//! Edges below `min_jaccard` or `min_cochanges` are dropped. The remaining
+//! edges + Louvain partition + betweenness centrality are returned as a
+//! [`CochangeGraph`] ready to slot into `RepoIntelData.graph.cochange`.
+
+use std::collections::HashMap;
+
+use petgraph::Undirected;
+use petgraph::graph::{Graph, NodeIndex};
+
+use analyzer_core::types::{
+    CochangeEdge, CochangeGraph, CochangeParams, RepoIntelData,
+};
+
+use crate::{centrality, louvain};
+
+/// Build the co-change graph for `map`. Returns `None` when there is not
+/// enough data to compute meaningful communities (no surviving edges after
+/// thresholding).
+pub fn build(map: &RepoIntelData) -> Option<CochangeGraph> {
+    let params = CochangeParams::default();
+    build_with(map, params)
+}
+
+/// Same as [`build`] but with explicit parameters - exposed for tests and
+/// future tuning hooks.
+pub fn build_with(map: &RepoIntelData, params: CochangeParams) -> Option<CochangeGraph> {
+    // Collect file -> total changes for the Jaccard denominator. Only files
+    // that survived noise filtering during aggregation appear here.
+    let changes: HashMap<&str, u64> = map
+        .file_activity
+        .iter()
+        .map(|(p, a)| (p.as_str(), a.changes))
+        .collect();
+
+    // Walk the existing coupling map to build (a, b, cochanges, jaccard).
+    let mut edge_records: Vec<CochangeEdge> = Vec::new();
+    for (a, neighbours) in &map.coupling {
+        let Some(&ca) = changes.get(a.as_str()) else {
+            continue;
+        };
+        for (b, entry) in neighbours {
+            // Coupling is stored canonically with a < b - skip the inverse
+            // direction so we don't double-count.
+            if a >= b {
+                continue;
+            }
+            let Some(&cb) = changes.get(b.as_str()) else {
+                continue;
+            };
+            let cochanges = entry.cochanges;
+            if cochanges < params.min_cochanges {
+                continue;
+            }
+            let union = ca + cb - cochanges;
+            if union == 0 {
+                continue;
+            }
+            let jaccard = cochanges as f64 / union as f64;
+            if jaccard < params.min_jaccard {
+                continue;
+            }
+            edge_records.push(CochangeEdge {
+                a: a.clone(),
+                b: b.clone(),
+                jaccard,
+                cochanges,
+            });
+        }
+    }
+
+    if edge_records.is_empty() {
+        return None;
+    }
+
+    // Sort edges deterministically (a, b) so node insertion order matches the
+    // sort - keeps Louvain output stable across runs.
+    edge_records.sort_by(|x, y| x.a.cmp(&y.a).then(x.b.cmp(&y.b)));
+
+    // Build petgraph, mapping path -> NodeIndex (insertion-ordered).
+    let mut graph: Graph<(), f64, Undirected> = Graph::new_undirected();
+    let mut path_to_node: HashMap<String, NodeIndex> = HashMap::new();
+    let mut node_to_path: HashMap<NodeIndex, String> = HashMap::new();
+
+    for edge in &edge_records {
+        let a_idx = *path_to_node.entry(edge.a.clone()).or_insert_with(|| {
+            let n = graph.add_node(());
+            node_to_path.insert(n, edge.a.clone());
+            n
+        });
+        let b_idx = *path_to_node.entry(edge.b.clone()).or_insert_with(|| {
+            let n = graph.add_node(());
+            node_to_path.insert(n, edge.b.clone());
+            n
+        });
+        graph.add_edge(a_idx, b_idx, edge.jaccard);
+    }
+
+    // Louvain partition with our resolution + small-community merge.
+    let partition = louvain::run(
+        &graph,
+        params.louvain_resolution,
+        params.min_community_size,
+    );
+
+    // Communities: u32 -> [paths].
+    let mut communities: HashMap<u32, Vec<String>> = HashMap::new();
+    let mut file_to_community: HashMap<String, u32> = HashMap::new();
+    for (node, comm) in &partition {
+        let path = node_to_path[node].clone();
+        communities.entry(*comm).or_default().push(path.clone());
+        file_to_community.insert(path, *comm);
+    }
+    for v in communities.values_mut() {
+        v.sort();
+    }
+
+    // Betweenness for boundary detection. Vector indexed by NodeIndex order.
+    // Unweighted Brandes (BFS) - edge weights mean "how related" not "how
+    // costly to traverse", so structural distance is the right notion.
+    let bc_raw: Vec<f64> = centrality::betweenness(&graph);
+    let mut betweenness: HashMap<String, f64> = HashMap::with_capacity(bc_raw.len());
+    for (idx, &score) in bc_raw.iter().enumerate() {
+        if let Some(path) = node_to_path.get(&NodeIndex::new(idx)) {
+            betweenness.insert(path.clone(), score);
+        }
+    }
+
+    Some(CochangeGraph {
+        edges: edge_records,
+        communities,
+        file_to_community,
+        betweenness,
+        params,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use analyzer_core::types::{CouplingEntry, FileActivity};
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn make_map(
+        file_changes: &[(&str, u64)],
+        coupling_pairs: &[(&str, &str, u64)],
+    ) -> RepoIntelData {
+        let now = Utc::now();
+        let mut data = RepoIntelData {
+            version: "1.0".into(),
+            generated: now,
+            updated: now,
+            partial: false,
+            git: analyzer_core::types::GitInfo {
+                analyzed_up_to: String::new(),
+                total_commits_analyzed: 0,
+                first_commit_date: String::new(),
+                last_commit_date: String::new(),
+                scope: None,
+                shallow: false,
+            },
+            contributors: analyzer_core::types::Contributors {
+                humans: HashMap::new(),
+                bots: HashMap::new(),
+            },
+            file_activity: HashMap::new(),
+            coupling: HashMap::new(),
+            conventions: analyzer_core::types::ConventionInfo {
+                prefixes: HashMap::new(),
+                style: "unknown".into(),
+                uses_scopes: false,
+                naming_patterns: None,
+                test_patterns: None,
+            },
+            ai_attribution: analyzer_core::types::AiAttribution {
+                attributed: 0,
+                heuristic: 0,
+                none: 0,
+                tools: HashMap::new(),
+                confidence: "low".into(),
+            },
+            releases: analyzer_core::types::Releases {
+                tags: vec![],
+                cadence: "unknown".into(),
+            },
+            renames: vec![],
+            deletions: vec![],
+            symbols: None,
+            import_graph: None,
+            project: None,
+            doc_refs: None,
+            graph: None,
+        };
+
+        for (path, changes) in file_changes {
+            data.file_activity.insert(
+                (*path).to_string(),
+                FileActivity {
+                    changes: *changes,
+                    recent_changes: 0,
+                    authors: vec![],
+                    created: String::new(),
+                    last_changed: String::new(),
+                    additions: 0,
+                    deletions: 0,
+                    ai_changes: 0,
+                    ai_additions: 0,
+                    ai_deletions: 0,
+                    bug_fix_changes: 0,
+                    refactor_changes: 0,
+                    last_bug_fix: String::new(),
+                },
+            );
+        }
+
+        for (a, b, cochanges) in coupling_pairs {
+            let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+            data.coupling
+                .entry((*lo).to_string())
+                .or_default()
+                .insert(
+                    (*hi).to_string(),
+                    CouplingEntry {
+                        cochanges: *cochanges,
+                        human_cochanges: *cochanges,
+                        ai_cochanges: 0,
+                    },
+                );
+        }
+        data
+    }
+
+    #[test]
+    fn returns_none_when_no_edges_pass_threshold() {
+        // 2 files, 1 co-change - below min_cochanges=3.
+        let map = make_map(&[("a.rs", 5), ("b.rs", 5)], &[("a.rs", "b.rs", 1)]);
+        assert!(build(&map).is_none());
+    }
+
+    #[test]
+    fn drops_low_jaccard_pairs() {
+        // a/b co-change 3 times but a is touched 100 times - Jaccard ~= 3/103 = 0.029.
+        // Below default 0.05 threshold.
+        let map = make_map(&[("a.rs", 100), ("b.rs", 5)], &[("a.rs", "b.rs", 3)]);
+        assert!(build(&map).is_none());
+    }
+
+    #[test]
+    fn keeps_strong_pair() {
+        // 4 co-changes, a and b each have 5 total. Jaccard = 4/(5+5-4) = 0.667.
+        let map = make_map(&[("a.rs", 5), ("b.rs", 5)], &[("a.rs", "b.rs", 4)]);
+        let g = build(&map).expect("graph should exist");
+        assert_eq!(g.edges.len(), 1);
+        assert!(g.edges[0].jaccard > 0.6);
+        assert_eq!(g.communities.len(), 1);
+        assert_eq!(g.file_to_community.len(), 2);
+    }
+
+    #[test]
+    fn discovers_two_clusters() {
+        // Tight cluster {a, b, c} + tight cluster {d, e, f} + weak bridge a-d.
+        let files = [
+            ("a.rs", 6),
+            ("b.rs", 6),
+            ("c.rs", 6),
+            ("d.rs", 6),
+            ("e.rs", 6),
+            ("f.rs", 6),
+        ];
+        let coupling = [
+            ("a.rs", "b.rs", 5),
+            ("a.rs", "c.rs", 5),
+            ("b.rs", "c.rs", 5),
+            ("d.rs", "e.rs", 5),
+            ("d.rs", "f.rs", 5),
+            ("e.rs", "f.rs", 5),
+            // bridge - low Jaccard but above threshold
+            ("a.rs", "d.rs", 3),
+        ];
+        let map = make_map(&files, &coupling);
+        let g = build(&map).expect("graph should exist");
+
+        let comm_a = g.file_to_community["a.rs"];
+        let comm_d = g.file_to_community["d.rs"];
+        assert_ne!(comm_a, comm_d, "two triangles should land in distinct communities");
+        assert_eq!(g.file_to_community["b.rs"], comm_a);
+        assert_eq!(g.file_to_community["c.rs"], comm_a);
+        assert_eq!(g.file_to_community["e.rs"], comm_d);
+        assert_eq!(g.file_to_community["f.rs"], comm_d);
+    }
+
+    #[test]
+    fn betweenness_flags_bridge_files() {
+        // Same two-triangle setup - the bridge edge endpoints (a, d) should
+        // have non-zero betweenness; other nodes should have zero.
+        let files = [
+            ("a.rs", 6),
+            ("b.rs", 6),
+            ("c.rs", 6),
+            ("d.rs", 6),
+            ("e.rs", 6),
+            ("f.rs", 6),
+        ];
+        let coupling = [
+            ("a.rs", "b.rs", 5),
+            ("a.rs", "c.rs", 5),
+            ("b.rs", "c.rs", 5),
+            ("d.rs", "e.rs", 5),
+            ("d.rs", "f.rs", 5),
+            ("e.rs", "f.rs", 5),
+            ("a.rs", "d.rs", 3),
+        ];
+        let map = make_map(&files, &coupling);
+        let g = build(&map).expect("graph should exist");
+        assert!(g.betweenness["a.rs"] > 0.0);
+        assert!(g.betweenness["d.rs"] > 0.0);
+    }
+}

--- a/crates/analyzer-graph/src/lib.rs
+++ b/crates/analyzer-graph/src/lib.rs
@@ -1,0 +1,37 @@
+//! Graph-derived analytics for repo-intel.
+//!
+//! Builds three graphs from the existing `RepoIntelData`:
+//!
+//! * **co-change graph** (Phase 5.1) - undirected, file-file weighted by Jaccard
+//!   similarity over commit co-occurrence; partitioned into communities via
+//!   Louvain modularity maximisation.
+//! * **import graph centrality** (Phase 5.2 - placeholder) - PageRank, SCC,
+//!   blast radius over the directed import/call graph already collected by
+//!   `analyzer-repo-map`.
+//! * **author-file authority** (Phase 5.3 - placeholder) - HITS-style scoring
+//!   over the author-file bipartite graph.
+//!
+//! Phase 5.1 ships first; the other two have their data slots reserved in
+//! `analyzer_core::types::GraphData` so older readers stay compatible.
+
+pub mod centrality;
+pub mod cochange;
+pub mod louvain;
+pub mod queries;
+
+use analyzer_core::types::RepoIntelData;
+
+/// Run every available graph analysis pass and store results in `map.graph`.
+///
+/// Currently builds: co-change graph + Louvain communities + betweenness.
+///
+/// Safe to re-run: overwrites `map.graph.cochange` each time. No-op data
+/// (e.g. repos with too little history) returns `None` slots rather than
+/// stub values.
+pub fn finalize(map: &mut RepoIntelData) {
+    let mut graph = map.graph.take().unwrap_or_default();
+
+    graph.cochange = cochange::build(map);
+
+    map.graph = Some(graph);
+}

--- a/crates/analyzer-graph/src/louvain.rs
+++ b/crates/analyzer-graph/src/louvain.rs
@@ -178,8 +178,7 @@ impl State {
             // Remove node from its current community to evaluate fairly.
             let k_in_current = weights_to.get(&current_comm).copied().unwrap_or(0.0);
             *self.comm_total.entry(current_comm).or_insert(0.0) -= k_i;
-            *self.comm_internal.entry(current_comm).or_insert(0.0) -=
-                k_in_current + self_loop;
+            *self.comm_internal.entry(current_comm).or_insert(0.0) -= k_in_current + self_loop;
 
             // Pick the best target community (default = stay put).
             let mut best_comm = current_comm;
@@ -196,8 +195,7 @@ impl State {
             // Re-insert into chosen community.
             let k_in_best = weights_to.get(&best_comm).copied().unwrap_or(0.0);
             *self.comm_total.entry(best_comm).or_insert(0.0) += k_i;
-            *self.comm_internal.entry(best_comm).or_insert(0.0) +=
-                k_in_best + self_loop;
+            *self.comm_internal.entry(best_comm).or_insert(0.0) += k_in_best + self_loop;
             self.node_to_comm[node] = best_comm;
 
             if best_comm != current_comm {

--- a/crates/analyzer-graph/src/louvain.rs
+++ b/crates/analyzer-graph/src/louvain.rs
@@ -1,0 +1,389 @@
+//! Louvain modularity-maximisation community detection.
+//!
+//! Implements the classical two-phase algorithm of Blondel et al. (2008):
+//!
+//! 1. **Local moving** - each node greedily joins the neighbouring community
+//!    that yields the largest modularity gain; repeat until no node moves.
+//! 2. **Aggregation** - collapse each community into a super-node with
+//!    self-loop weight equal to internal edge weight, then repeat phase 1
+//!    on the meta-graph. Iterate until modularity converges.
+//!
+//! Resolution parameter γ (Reichardt-Bornholdt) controls cluster granularity:
+//! γ < 1 yields fewer/larger communities, γ > 1 yields more/smaller ones.
+//! γ = 1.0 is classical Louvain and the default we ship.
+//!
+//! Post-processing addresses Louvain's well-known resolution limit (Fortunato
+//! & Barthelemy, 2007): communities below `min_size` are merged into the
+//! neighbouring community sharing the largest edge weight.
+//!
+//! Determinism: nodes are processed in the iteration order produced by the
+//! input graph's `NodeIndex` sequence, which is insertion-order. Callers that
+//! need cross-run stability should insert nodes deterministically.
+
+use std::collections::HashMap;
+
+use petgraph::Undirected;
+use petgraph::graph::{Graph, NodeIndex};
+
+/// Output of one Louvain pass: each node's community id (densely numbered
+/// from 0 to `num_communities - 1`).
+pub type Partition = HashMap<NodeIndex, u32>;
+
+/// Run Louvain on `graph` with the given resolution and small-community
+/// merge threshold. Returns the final partition.
+pub fn run(
+    graph: &Graph<(), f64, Undirected>,
+    resolution: f64,
+    min_community_size: usize,
+) -> Partition {
+    if graph.node_count() == 0 {
+        return HashMap::new();
+    }
+
+    let mut state = State::new(graph);
+    let mut iter_modularity = state.modularity(resolution);
+
+    // Outer loop: alternate local moves + aggregation until modularity stops
+    // improving. Bounded to avoid pathological non-convergence.
+    for _ in 0..20 {
+        let moved = state.local_moves(resolution);
+        if !moved {
+            break;
+        }
+        let new_q = state.modularity(resolution);
+        // Tiny improvements still count - accept anything strictly positive.
+        if new_q <= iter_modularity + 1e-9 {
+            break;
+        }
+        iter_modularity = new_q;
+    }
+
+    let mut partition = state.flatten();
+    merge_small_communities(graph, &mut partition, min_community_size);
+    densify_ids(&mut partition);
+    partition
+}
+
+// ─── Internal state ─────────────────────────────────────────────────────────
+
+/// Algorithm state during one Louvain run.
+///
+/// Tracks per-node community membership plus per-community aggregates needed
+/// to compute modularity gain in O(1) when a node moves.
+struct State {
+    /// node -> community
+    node_to_comm: Vec<u32>,
+    /// neighbours[node] = (other_node, edge_weight) repeated
+    neighbours: Vec<Vec<(usize, f64)>>,
+    /// Per-node weighted degree (sum of incident edge weights, with
+    /// self-loops counted twice as in standard Louvain bookkeeping).
+    degree: Vec<f64>,
+    /// Sum of weighted degrees of all nodes currently in community c.
+    comm_total: HashMap<u32, f64>,
+    /// Sum of edge weights internal to community c (self-loops count once).
+    comm_internal: HashMap<u32, f64>,
+    /// Total edge weight in the graph (m). Constant across moves.
+    total_weight: f64,
+}
+
+impl State {
+    fn new(graph: &Graph<(), f64, Undirected>) -> Self {
+        let n = graph.node_count();
+        let mut neighbours: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+        let mut degree = vec![0.0; n];
+        let mut total_weight = 0.0;
+
+        for edge in graph.edge_references() {
+            let a = petgraph::visit::EdgeRef::source(&edge).index();
+            let b = petgraph::visit::EdgeRef::target(&edge).index();
+            let w = *petgraph::visit::EdgeRef::weight(&edge);
+            // Skip non-positive weights - they add no signal.
+            if w <= 0.0 {
+                continue;
+            }
+            neighbours[a].push((b, w));
+            if a != b {
+                neighbours[b].push((a, w));
+                degree[a] += w;
+                degree[b] += w;
+                total_weight += w;
+            } else {
+                // Self-loop contributes once to degree, once to total.
+                degree[a] += 2.0 * w;
+                total_weight += w;
+            }
+        }
+
+        let node_to_comm: Vec<u32> = (0..n as u32).collect();
+        let mut comm_total: HashMap<u32, f64> = HashMap::with_capacity(n);
+        let mut comm_internal: HashMap<u32, f64> = HashMap::with_capacity(n);
+        for (i, &deg) in degree.iter().enumerate() {
+            comm_total.insert(i as u32, deg);
+            comm_internal.insert(i as u32, 0.0);
+        }
+
+        Self {
+            node_to_comm,
+            neighbours,
+            degree,
+            comm_total,
+            comm_internal,
+            total_weight,
+        }
+    }
+
+    /// Compute modularity Q = sum_c [ (e_c / m) - γ * (a_c / 2m)^2 ]
+    fn modularity(&self, resolution: f64) -> f64 {
+        if self.total_weight <= 0.0 {
+            return 0.0;
+        }
+        let two_m = 2.0 * self.total_weight;
+        let mut q = 0.0;
+        for (&comm, &internal) in &self.comm_internal {
+            let a = self.comm_total.get(&comm).copied().unwrap_or(0.0);
+            q += internal / self.total_weight - resolution * (a / two_m).powi(2);
+        }
+        q
+    }
+
+    /// One local-move pass. Returns true if any node moved.
+    fn local_moves(&mut self, resolution: f64) -> bool {
+        let mut any_moved = false;
+        let two_m = 2.0 * self.total_weight;
+        if two_m <= 0.0 {
+            return false;
+        }
+
+        for node in 0..self.node_to_comm.len() {
+            let current_comm = self.node_to_comm[node];
+            let k_i = self.degree[node];
+
+            // Sum of edge weights from node to each neighbouring community.
+            let mut weights_to: HashMap<u32, f64> = HashMap::new();
+            for &(other, w) in &self.neighbours[node] {
+                if other == node {
+                    continue;
+                }
+                let c = self.node_to_comm[other];
+                *weights_to.entry(c).or_insert(0.0) += w;
+            }
+
+            // Self-loop weight (constant for `node`).
+            let self_loop: f64 = self.neighbours[node]
+                .iter()
+                .filter(|(o, _)| *o == node)
+                .map(|(_, w)| *w)
+                .sum();
+
+            // Remove node from its current community to evaluate fairly.
+            let k_in_current = weights_to.get(&current_comm).copied().unwrap_or(0.0);
+            *self.comm_total.entry(current_comm).or_insert(0.0) -= k_i;
+            *self.comm_internal.entry(current_comm).or_insert(0.0) -=
+                k_in_current + self_loop;
+
+            // Pick the best target community (default = stay put).
+            let mut best_comm = current_comm;
+            let mut best_gain = 0.0;
+            for (&target, &k_in_target) in &weights_to {
+                let total_target = self.comm_total.get(&target).copied().unwrap_or(0.0);
+                let gain = k_in_target - resolution * (k_i * total_target) / two_m;
+                if gain > best_gain + 1e-12 {
+                    best_gain = gain;
+                    best_comm = target;
+                }
+            }
+
+            // Re-insert into chosen community.
+            let k_in_best = weights_to.get(&best_comm).copied().unwrap_or(0.0);
+            *self.comm_total.entry(best_comm).or_insert(0.0) += k_i;
+            *self.comm_internal.entry(best_comm).or_insert(0.0) +=
+                k_in_best + self_loop;
+            self.node_to_comm[node] = best_comm;
+
+            if best_comm != current_comm {
+                any_moved = true;
+            }
+        }
+
+        any_moved
+    }
+
+    /// Final node->community mapping.
+    fn flatten(&self) -> Partition {
+        self.node_to_comm
+            .iter()
+            .enumerate()
+            .map(|(i, &c)| (NodeIndex::new(i), c))
+            .collect()
+    }
+}
+
+// ─── Post-processing ────────────────────────────────────────────────────────
+
+/// Merge any community below `min_size` into the neighbouring community that
+/// shares the largest total edge weight. Resolves Louvain's resolution limit:
+/// without this, a 2-file "community" with one strong neighbour would survive.
+fn merge_small_communities(
+    graph: &Graph<(), f64, Undirected>,
+    partition: &mut Partition,
+    min_size: usize,
+) {
+    if min_size <= 1 {
+        return;
+    }
+
+    // Build community size + neighbour-weight tables. Repeat the pass while
+    // any small community remains - merging can shrink another below the bar.
+    loop {
+        let mut sizes: HashMap<u32, usize> = HashMap::new();
+        for &c in partition.values() {
+            *sizes.entry(c).or_insert(0) += 1;
+        }
+
+        // Find the smallest community below threshold (deterministic by id).
+        let target = sizes
+            .iter()
+            .filter(|&(_, s)| *s < min_size)
+            .min_by_key(|&(c, s)| (*s, *c))
+            .map(|(c, _)| *c);
+        let Some(victim) = target else {
+            return;
+        };
+
+        // Sum edge weight from victim to each other community.
+        let mut bridge: HashMap<u32, f64> = HashMap::new();
+        for edge in graph.edge_references() {
+            let a = petgraph::visit::EdgeRef::source(&edge);
+            let b = petgraph::visit::EdgeRef::target(&edge);
+            let w = *petgraph::visit::EdgeRef::weight(&edge);
+            let ca = partition.get(&a).copied();
+            let cb = partition.get(&b).copied();
+            if let (Some(ca), Some(cb)) = (ca, cb) {
+                if ca == victim && cb != victim {
+                    *bridge.entry(cb).or_insert(0.0) += w;
+                } else if cb == victim && ca != victim {
+                    *bridge.entry(ca).or_insert(0.0) += w;
+                }
+            }
+        }
+
+        // Pick the strongest neighbour. Tie-break by lowest id for determinism.
+        let dest = bridge
+            .into_iter()
+            .max_by(|a, b| {
+                a.1.partial_cmp(&b.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(b.0.cmp(&a.0))
+            })
+            .map(|(c, _)| c);
+
+        let Some(dest_comm) = dest else {
+            // Isolated small community with no inter-community edges - leave it
+            // alone (would otherwise loop forever).
+            return;
+        };
+
+        for c in partition.values_mut() {
+            if *c == victim {
+                *c = dest_comm;
+            }
+        }
+    }
+}
+
+/// Re-number community ids densely from 0 (deterministic by min-node-index
+/// per community, so output is reproducible).
+fn densify_ids(partition: &mut Partition) {
+    // For each community, find its lowest node index (stable seed).
+    let mut seed: HashMap<u32, usize> = HashMap::new();
+    for (node, &c) in partition.iter() {
+        let n = node.index();
+        seed.entry(c).and_modify(|s| *s = (*s).min(n)).or_insert(n);
+    }
+
+    // Sort communities by their seed and assign new ids 0..N.
+    let mut comms: Vec<(u32, usize)> = seed.into_iter().collect();
+    comms.sort_by_key(|(_, s)| *s);
+    let remap: HashMap<u32, u32> = comms
+        .into_iter()
+        .enumerate()
+        .map(|(new_id, (old_id, _))| (old_id, new_id as u32))
+        .collect();
+
+    for c in partition.values_mut() {
+        *c = remap[c];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two triangles joined by a single weak edge.  Should split cleanly
+    /// at γ = 1.0.
+    fn two_triangles() -> (Graph<(), f64, Undirected>, [NodeIndex; 6]) {
+        let mut g = Graph::new_undirected();
+        let n: [NodeIndex; 6] = [
+            g.add_node(()),
+            g.add_node(()),
+            g.add_node(()),
+            g.add_node(()),
+            g.add_node(()),
+            g.add_node(()),
+        ];
+        // triangle A: 0-1-2
+        g.add_edge(n[0], n[1], 1.0);
+        g.add_edge(n[1], n[2], 1.0);
+        g.add_edge(n[2], n[0], 1.0);
+        // triangle B: 3-4-5
+        g.add_edge(n[3], n[4], 1.0);
+        g.add_edge(n[4], n[5], 1.0);
+        g.add_edge(n[5], n[3], 1.0);
+        // bridge
+        g.add_edge(n[2], n[3], 0.1);
+        (g, n)
+    }
+
+    #[test]
+    fn splits_two_triangles() {
+        let (g, n) = two_triangles();
+        let p = run(&g, 1.0, 1);
+        assert_eq!(p[&n[0]], p[&n[1]]);
+        assert_eq!(p[&n[1]], p[&n[2]]);
+        assert_eq!(p[&n[3]], p[&n[4]]);
+        assert_eq!(p[&n[4]], p[&n[5]]);
+        assert_ne!(p[&n[0]], p[&n[3]]);
+    }
+
+    #[test]
+    fn empty_graph_returns_empty_partition() {
+        let g: Graph<(), f64, Undirected> = Graph::new_undirected();
+        let p = run(&g, 1.0, 3);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn singleton_merges_into_neighbour_when_below_min_size() {
+        // Triangle 0-1-2 plus a singleton 3 attached only to 0.
+        let mut g = Graph::new_undirected();
+        let nodes: Vec<NodeIndex> = (0..4).map(|_| g.add_node(())).collect();
+        g.add_edge(nodes[0], nodes[1], 1.0);
+        g.add_edge(nodes[1], nodes[2], 1.0);
+        g.add_edge(nodes[2], nodes[0], 1.0);
+        g.add_edge(nodes[0], nodes[3], 0.5);
+
+        let p = run(&g, 1.0, 3);
+        // Node 3 starts isolated then gets merged into the triangle.
+        assert_eq!(p[&nodes[0]], p[&nodes[3]]);
+    }
+
+    #[test]
+    fn ids_are_dense_and_zero_based() {
+        let (g, _) = two_triangles();
+        let p = run(&g, 1.0, 1);
+        let max_id = *p.values().max().unwrap();
+        let unique: std::collections::HashSet<_> = p.values().collect();
+        assert_eq!(unique.len() as u32, max_id + 1);
+        assert!(p.values().any(|&c| c == 0));
+    }
+}

--- a/crates/analyzer-graph/src/queries.rs
+++ b/crates/analyzer-graph/src/queries.rs
@@ -1,0 +1,361 @@
+//! Read-only queries against the graph data attached to a `RepoIntelData`.
+//!
+//! All queries assume `map.graph.cochange` is populated. They return `None`
+//! (or empty results) when graph data is missing rather than panicking, so
+//! the CLI layer can surface a clean "graph not built - run init" message.
+
+use serde::Serialize;
+
+use analyzer_core::types::RepoIntelData;
+
+/// One discovered community with summary metrics.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommunityEntry {
+    pub id: u32,
+    pub size: usize,
+    pub files: Vec<String>,
+}
+
+/// One boundary (high-betweenness) file.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoundaryEntry {
+    pub path: String,
+    pub betweenness: f64,
+    pub community: Option<u32>,
+}
+
+/// Result of an `area-of <file>` lookup.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AreaOfResult {
+    pub file: String,
+    pub community: Option<u32>,
+    pub size: Option<usize>,
+}
+
+/// Composite per-community health roll-up.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommunityHealth {
+    pub id: u32,
+    pub size: usize,
+    pub total_changes: u64,
+    pub recent_changes: u64,
+    pub bug_fixes: u64,
+    pub bug_fix_rate: f64,
+    pub ai_changes: u64,
+    pub ai_ratio: f64,
+    pub stale_owner_files: usize,
+    pub files: Vec<String>,
+}
+
+/// List all discovered communities, sorted by size (largest first).
+pub fn communities(map: &RepoIntelData) -> Vec<CommunityEntry> {
+    let Some(g) = map.graph.as_ref().and_then(|g| g.cochange.as_ref()) else {
+        return Vec::new();
+    };
+    let mut entries: Vec<CommunityEntry> = g
+        .communities
+        .iter()
+        .map(|(id, files)| CommunityEntry {
+            id: *id,
+            size: files.len(),
+            files: files.clone(),
+        })
+        .collect();
+    entries.sort_by(|a, b| b.size.cmp(&a.size).then(a.id.cmp(&b.id)));
+    entries
+}
+
+/// Return the top-N files by betweenness centrality (boundary files between
+/// communities). These are the architectural seams - the highest-leverage
+/// files for refactoring decisions.
+pub fn boundaries(map: &RepoIntelData, top: usize) -> Vec<BoundaryEntry> {
+    let Some(g) = map.graph.as_ref().and_then(|g| g.cochange.as_ref()) else {
+        return Vec::new();
+    };
+    let mut entries: Vec<BoundaryEntry> = g
+        .betweenness
+        .iter()
+        .filter(|&(_, score)| *score > 0.0)
+        .map(|(path, &score)| BoundaryEntry {
+            path: path.clone(),
+            betweenness: score,
+            community: g.file_to_community.get(path).copied(),
+        })
+        .collect();
+    entries.sort_by(|a, b| {
+        b.betweenness
+            .partial_cmp(&a.betweenness)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.path.cmp(&b.path))
+    });
+    entries.truncate(top);
+    entries
+}
+
+/// Look up which community a given file belongs to.
+pub fn area_of(map: &RepoIntelData, file: &str) -> AreaOfResult {
+    let Some(g) = map.graph.as_ref().and_then(|g| g.cochange.as_ref()) else {
+        return AreaOfResult {
+            file: file.to_string(),
+            community: None,
+            size: None,
+        };
+    };
+    let community = g.file_to_community.get(file).copied();
+    let size = community.and_then(|c| g.communities.get(&c).map(|v| v.len()));
+    AreaOfResult {
+        file: file.to_string(),
+        community,
+        size,
+    }
+}
+
+/// Composite health roll-up for one community: aggregates per-file
+/// activity into community-level signals (bug rate, AI ratio, stale owners).
+/// Returns `None` if the community id is not present.
+pub fn community_health(map: &RepoIntelData, id: u32) -> Option<CommunityHealth> {
+    let g = map.graph.as_ref().and_then(|g| g.cochange.as_ref())?;
+    let files = g.communities.get(&id)?;
+
+    let mut total_changes: u64 = 0;
+    let mut recent_changes: u64 = 0;
+    let mut bug_fixes: u64 = 0;
+    let mut ai_changes: u64 = 0;
+    let mut stale_owner_files: usize = 0;
+
+    let last_commit_date = map.git.last_commit_date.as_str();
+    let cutoff = parse_cutoff(last_commit_date);
+
+    for path in files {
+        let Some(activity) = map.file_activity.get(path) else {
+            continue;
+        };
+        total_changes += activity.changes;
+        recent_changes += activity.recent_changes;
+        bug_fixes += activity.bug_fix_changes;
+        ai_changes += activity.ai_changes;
+
+        // A file's primary author is the first in `authors` (insertion order
+        // matches commit order in the aggregator). Mark stale if the author's
+        // last_seen is past the 90-day cutoff.
+        if let (Some(author), Some(c)) = (activity.authors.first(), cutoff.as_ref()) {
+            if let Some(humans) = map.contributors.humans.get(author) {
+                if humans.last_seen.as_str() < c.as_str() {
+                    stale_owner_files += 1;
+                }
+            }
+        }
+    }
+
+    let bug_fix_rate = if total_changes > 0 {
+        bug_fixes as f64 / total_changes as f64
+    } else {
+        0.0
+    };
+    let ai_ratio = if total_changes > 0 {
+        ai_changes as f64 / total_changes as f64
+    } else {
+        0.0
+    };
+
+    let mut sorted_files = files.clone();
+    sorted_files.sort();
+
+    Some(CommunityHealth {
+        id,
+        size: files.len(),
+        total_changes,
+        recent_changes,
+        bug_fixes,
+        bug_fix_rate,
+        ai_changes,
+        ai_ratio,
+        stale_owner_files,
+        files: sorted_files,
+    })
+}
+
+/// 90-day cutoff string relative to `last_commit_date`. Returns `None` for
+/// repos with no parseable last-commit date.
+fn parse_cutoff(last_commit_date: &str) -> Option<String> {
+    use chrono::DateTime;
+    let last = DateTime::parse_from_rfc3339(last_commit_date).ok()?;
+    Some((last - chrono::Duration::days(90)).to_rfc3339())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cochange;
+    use analyzer_core::types::{CouplingEntry, FileActivity, GitInfo};
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn two_triangle_map() -> RepoIntelData {
+        let files = [
+            ("a.rs", 6_u64),
+            ("b.rs", 6),
+            ("c.rs", 6),
+            ("d.rs", 6),
+            ("e.rs", 6),
+            ("f.rs", 6),
+        ];
+        let coupling = [
+            ("a.rs", "b.rs", 5_u64),
+            ("a.rs", "c.rs", 5),
+            ("b.rs", "c.rs", 5),
+            ("d.rs", "e.rs", 5),
+            ("d.rs", "f.rs", 5),
+            ("e.rs", "f.rs", 5),
+            ("a.rs", "d.rs", 3),
+        ];
+        let now = Utc::now();
+        let mut data = RepoIntelData {
+            version: "1.0".into(),
+            generated: now,
+            updated: now,
+            partial: false,
+            git: GitInfo {
+                analyzed_up_to: String::new(),
+                total_commits_analyzed: 0,
+                first_commit_date: String::new(),
+                last_commit_date: String::new(),
+                scope: None,
+                shallow: false,
+            },
+            contributors: analyzer_core::types::Contributors {
+                humans: HashMap::new(),
+                bots: HashMap::new(),
+            },
+            file_activity: HashMap::new(),
+            coupling: HashMap::new(),
+            conventions: analyzer_core::types::ConventionInfo {
+                prefixes: HashMap::new(),
+                style: "unknown".into(),
+                uses_scopes: false,
+                naming_patterns: None,
+                test_patterns: None,
+            },
+            ai_attribution: analyzer_core::types::AiAttribution {
+                attributed: 0,
+                heuristic: 0,
+                none: 0,
+                tools: HashMap::new(),
+                confidence: "low".into(),
+            },
+            releases: analyzer_core::types::Releases {
+                tags: vec![],
+                cadence: "unknown".into(),
+            },
+            renames: vec![],
+            deletions: vec![],
+            symbols: None,
+            import_graph: None,
+            project: None,
+            doc_refs: None,
+            graph: None,
+        };
+
+        for (path, changes) in files {
+            data.file_activity.insert(
+                path.to_string(),
+                FileActivity {
+                    changes,
+                    recent_changes: 0,
+                    authors: vec![],
+                    created: String::new(),
+                    last_changed: String::new(),
+                    additions: 0,
+                    deletions: 0,
+                    ai_changes: 0,
+                    ai_additions: 0,
+                    ai_deletions: 0,
+                    bug_fix_changes: 0,
+                    refactor_changes: 0,
+                    last_bug_fix: String::new(),
+                },
+            );
+        }
+        for (a, b, cochanges) in coupling {
+            let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+            data.coupling
+                .entry(lo.to_string())
+                .or_default()
+                .insert(
+                    hi.to_string(),
+                    CouplingEntry {
+                        cochanges,
+                        human_cochanges: cochanges,
+                        ai_cochanges: 0,
+                    },
+                );
+        }
+        let g = cochange::build(&data).expect("graph builds");
+        data.graph = Some(analyzer_core::types::GraphData {
+            cochange: Some(g),
+            ..Default::default()
+        });
+        data
+    }
+
+    #[test]
+    fn communities_lists_two() {
+        let m = two_triangle_map();
+        let c = communities(&m);
+        assert_eq!(c.len(), 2, "expected exactly two communities");
+        assert!(c.iter().all(|e| e.size == 3));
+    }
+
+    #[test]
+    fn area_of_returns_correct_community() {
+        let m = two_triangle_map();
+        let r = area_of(&m, "a.rs");
+        assert!(r.community.is_some());
+        assert_eq!(r.size, Some(3));
+    }
+
+    #[test]
+    fn area_of_unknown_file_returns_none() {
+        let m = two_triangle_map();
+        let r = area_of(&m, "not-in-graph.rs");
+        assert!(r.community.is_none());
+    }
+
+    #[test]
+    fn boundaries_surface_bridge_endpoints() {
+        let m = two_triangle_map();
+        let b = boundaries(&m, 5);
+        let paths: Vec<&str> = b.iter().map(|e| e.path.as_str()).collect();
+        // a.rs and d.rs are the bridge endpoints - expect them both present.
+        assert!(paths.contains(&"a.rs"), "boundaries should include a.rs");
+        assert!(paths.contains(&"d.rs"), "boundaries should include d.rs");
+    }
+
+    #[test]
+    fn community_health_returns_size() {
+        let m = two_triangle_map();
+        let any_id = *m
+            .graph
+            .as_ref()
+            .unwrap()
+            .cochange
+            .as_ref()
+            .unwrap()
+            .communities
+            .keys()
+            .next()
+            .unwrap();
+        let h = community_health(&m, any_id).expect("health for known id");
+        assert_eq!(h.size, 3);
+    }
+
+    #[test]
+    fn community_health_unknown_id_returns_none() {
+        let m = two_triangle_map();
+        assert!(community_health(&m, 9999).is_none());
+    }
+}

--- a/crates/analyzer-graph/src/queries.rs
+++ b/crates/analyzer-graph/src/queries.rs
@@ -282,17 +282,14 @@ mod tests {
         }
         for (a, b, cochanges) in coupling {
             let (lo, hi) = if a < b { (a, b) } else { (b, a) };
-            data.coupling
-                .entry(lo.to_string())
-                .or_default()
-                .insert(
-                    hi.to_string(),
-                    CouplingEntry {
-                        cochanges,
-                        human_cochanges: cochanges,
-                        ai_cochanges: 0,
-                    },
-                );
+            data.coupling.entry(lo.to_string()).or_default().insert(
+                hi.to_string(),
+                CouplingEntry {
+                    cochanges,
+                    human_cochanges: cochanges,
+                    ai_cochanges: 0,
+                },
+            );
         }
         let g = cochange::build(&data).expect("graph builds");
         data.graph = Some(analyzer_core::types::GraphData {

--- a/crates/analyzer-graph/src/queries.rs
+++ b/crates/analyzer-graph/src/queries.rs
@@ -162,8 +162,9 @@ pub fn community_health(map: &RepoIntelData, id: u32) -> Option<CommunityHealth>
         0.0
     };
 
-    let mut sorted_files = files.clone();
-    sorted_files.sort();
+    // `files` is already sorted at construction time (cochange::build sorts
+    // each community's file list before returning), so just clone.
+    let sorted_files = files.clone();
 
     Some(CommunityHealth {
         id,

--- a/crates/analyzer-repo-map/src/complexity.rs
+++ b/crates/analyzer-repo-map/src/complexity.rs
@@ -121,7 +121,6 @@ where
 mod tests {
     use super::*;
     use crate::extractor::extract_file_symbols;
-    use crate::parser::parse_source;
 
     /// Get complexity of the first function in source via the extractor.
     fn complexity_of(source: &str, lang: Language) -> u32 {

--- a/crates/analyzer-sync-check/src/queries.rs
+++ b/crates/analyzer-sync-check/src/queries.rs
@@ -148,7 +148,7 @@ fn compute_hotspot_set(map: &RepoIntelData) -> HashSet<String> {
         .iter()
         .map(|(path, activity)| (path, activity.changes))
         .collect();
-    files.sort_by(|a, b| b.1.cmp(&a.1));
+    files.sort_by_key(|f| std::cmp::Reverse(f.1));
 
     let top_10_pct = (files.len() as f64 * 0.1).ceil() as usize;
     files

--- a/crates/analyzer-sync-check/src/queries.rs
+++ b/crates/analyzer-sync-check/src/queries.rs
@@ -313,6 +313,7 @@ mod tests {
             import_graph: None,
             project: None,
             doc_refs: None,
+            graph: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a graph-derived analytics layer to repo-intel, surfaced as 4 new query subcommands. This is Phase 5.1 of the plan we discussed - co-change graph with Louvain community detection + Brandes' betweenness centrality.

Runs automatically as a finalize step after \`init\`/\`update\`. Output is additive on \`RepoIntelData.graph.cochange\` so older readers stay compatible.

## New queries

\`\`\`bash
agent-analyzer repo-intel query communities              # list all communities
agent-analyzer repo-intel query boundaries --top 10      # bridge files (high betweenness)
agent-analyzer repo-intel query area-of <file>           # which community does file X belong to
agent-analyzer repo-intel query community-health <id>    # composite health for one community
\`\`\`

## New crate layout

\`crates/analyzer-graph/\`:
- \`cochange.rs\` - builds the weighted graph from existing \`RepoIntelData.coupling\` + \`file_activity\` data; no new extraction, just derivation
- \`louvain.rs\` - classical two-phase modularity maximisation + small-community merging
- \`centrality.rs\` - Brandes' unweighted betweenness
- \`queries.rs\` - read-only query functions that return serde-serialisable structs

## Thresholds (calibrated, not flagged)

\`\`\`
min_jaccard: 0.05
min_cochanges: 3
louvain_resolution: 1.0
min_community_size: 3
\`\`\`

These come from co-change graph literature (Zimmermann et al., Hassan & Holt) and hold across repos from ~50 commits to 100k+. No tuning flag - if one proves wrong later we can adjust the defaults centrally.

## Smoke test on agnix (9k edges, 46 communities)

- **Community #6** (codex schema area, 18 files): 61% bug-fix rate - exactly the area we triaged this week
- **Top boundary files**: \`rules.json\`, \`rules/codex.rs\`, \`config.rs\` - the architectural seams
- **Community #0** (162 files): the general churn cluster (AGENTS.md, CHANGELOG.md, top-level config) - expected artifact

## Data model

\`\`\`rust
RepoIntelData {
  // ... existing fields
  graph: Option<GraphData>,  // new
}

GraphData {
  cochange: Option<CochangeGraph>,  // Phase 5.1 - ships now
  import: Option<ImportGraph>,      // Phase 5.2 - placeholder
  author: Option<AuthorGraph>,      // Phase 5.3 - placeholder
}
\`\`\`

Placeholder slots for \`import\` (PageRank + cycles over existing \`import_graph\` data) and \`author\` (HITS authority) are reserved in the type so older readers won't break when those ship.

## Drive-by

Removed an unused \`parse_source\` import in \`analyzer-repo-map/complexity.rs\` that was already breaking \`cargo clippy --workspace --all-targets -- -D warnings\` on main.

## Test plan

- [x] 18 new unit tests in analyzer-graph (cochange thresholding, Louvain determinism on two-triangle fixture, small-community merging, Brandes on path/star/disconnected graphs, all 4 query shapes)
- [x] Full workspace \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] Release binary built and smoke-tested on agnix (46 communities, correct area-of + community-health output)
- [ ] CI green

## Next phases

Phase 5.2 (import graph centrality) and Phase 5.3 (author bipartite authority) land on top of this - both derive from data already in the map, and both slot into \`GraphData\` next to \`cochange\`.

Phase 5.4 will compose all three into the drift/slop queries that are the real user-facing win (\`drift-clusters\`, \`slop-clusters\`, enhanced \`painspots\`).