### PR TITLE
feat(bugfix-detect): broaden classification beyond Conventional Commit prefix

### DIFF
--- a/crates/analyzer-core/src/bug_fix_detect.rs
+++ b/crates/analyzer-core/src/bug_fix_detect.rs
@@ -105,38 +105,46 @@ fn has_issue_closure(lower_subject: &str) -> bool {
 }
 
 fn followed_by_issue_ref(rest: &str) -> bool {
-    // Allow optional `:` and whitespace, then either `#NNN`, `gh-NNN`, or
-    // `<owner>/<repo>#NNN`. We only need a quick check, not a full parser.
+    // Allow optional `:` and whitespace, then either `#NNN`, `gh-NNN`,
+    // or `<owner>/<repo>#NNN` (where owner/repo may contain dots,
+    // dashes, and underscores - GitHub's repo-name rules). We only
+    // need a quick check, not a full parser.
+    //
+    // Note: `rest` is already lowercased by the caller, so we only
+    // need to look for the lowercase `gh-` form.
     let trimmed = rest.trim_start_matches([':', ' ', '\t']);
     let bytes = trimmed.as_bytes();
 
-    // Skip an optional `<word>/<word>` prefix (cross-repo references).
-    let mut idx = 0;
-    while idx < bytes.len()
-        && (bytes[idx].is_ascii_alphanumeric()
-            || bytes[idx] == b'-'
-            || bytes[idx] == b'_'
-            || bytes[idx] == b'/')
-    {
-        idx += 1;
-    }
-    let after_org = if idx > 0 && idx < bytes.len() && bytes[idx - 1] == b'/' {
-        &trimmed[idx..]
-    } else {
-        trimmed
-    };
-    let bytes = after_org.as_bytes();
-
+    // Direct forms: `#123`, `gh-123`.
     if bytes.starts_with(b"#") && bytes.len() > 1 && bytes[1].is_ascii_digit() {
         return true;
     }
-    if (bytes.starts_with(b"gh-") || bytes.starts_with(b"GH-"))
-        && bytes.len() > 3
-        && bytes[3].is_ascii_digit()
-    {
+    if bytes.starts_with(b"gh-") && bytes.len() > 3 && bytes[3].is_ascii_digit() {
         return true;
     }
-    false
+
+    // Cross-repo form: scan up to the first `#` and check that what
+    // came before looked like `<owner>/<repo>` (with at least one `/`,
+    // and only repo-name-legal characters).
+    let Some(hash_pos) = trimmed.find('#') else {
+        return false;
+    };
+    let prefix = &trimmed[..hash_pos];
+    let after = &trimmed[hash_pos..];
+    if !after.as_bytes().get(1).is_some_and(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    let Some(slash_pos) = prefix.find('/') else {
+        return false;
+    };
+    let owner = &prefix[..slash_pos];
+    let repo = &prefix[slash_pos + 1..];
+    let valid_segment = |s: &str| {
+        !s.is_empty()
+            && s.bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
+    };
+    valid_segment(owner) && valid_segment(repo)
 }
 
 fn find_word(haystack: &str, needle: &str) -> bool {
@@ -220,6 +228,30 @@ mod tests {
         assert!(is_bug_fix("Resolves GH-7"));
         assert!(is_bug_fix("Fix: resolves agent-sh/agnix#900"));
         assert!(is_bug_fix("close #1"));
+    }
+
+    #[test]
+    fn cross_repo_issue_refs_hit() {
+        // Subjects without any fix-related keyword should still register
+        // when they close a cross-repo issue. These exercise the
+        // `<owner>/<repo>#NNN` branch of has_issue_closure.
+        assert!(is_bug_fix("Closes agent-sh/agnix#900"));
+        assert!(is_bug_fix("Resolves rust-lang/rust#12345"));
+        // Repo names may contain dots (e.g. github.com style).
+        assert!(is_bug_fix("Closes my-org/my.repo.name#1"));
+        // And underscores.
+        assert!(is_bug_fix("Fixes some_org/some_repo#42"));
+    }
+
+    #[test]
+    fn malformed_cross_repo_refs_do_not_hit() {
+        // `#` not followed by a digit - should not register.
+        assert!(!is_bug_fix("Closes agent-sh/agnix#notanumber"));
+        // No slash before `#` - that's a single-repo ref, must follow a
+        // closure verb directly without an org prefix to count.
+        assert!(!is_bug_fix("Closes weird-thing#1"));
+        // Empty before `#`.
+        assert!(!is_bug_fix("Closes /#1"));
     }
 
     #[test]

--- a/crates/analyzer-core/src/bug_fix_detect.rs
+++ b/crates/analyzer-core/src/bug_fix_detect.rs
@@ -1,0 +1,246 @@
+//! Heuristic bug-fix classification for commit subjects.
+//!
+//! The original aggregator only counted commits whose Conventional Commit
+//! prefix was `fix:`. That misses every project that does not enforce
+//! Conventional Commits, plus several repos that *do* use it but file
+//! regressions under different verbs (`hotfix`, `revert`, `chore: fix the
+//! build`, plain "Fix race in foo", etc.). This module returns true when
+//! either:
+//!
+//!   1. the commit has a Conventional Commit prefix in [`FIX_PREFIXES`], or
+//!   2. the commit subject contains a fix-related keyword from
+//!      [`SUBJECT_KEYWORDS`], or
+//!   3. the commit references an issue closure (`fixes #123`, `closes #45`,
+//!      `resolves GH-7`).
+//!
+//! The keyword list is intentionally case-insensitive and word-boundary
+//! aware so that `fix:`, `Fixed`, `FIXES`, and `fixing` all hit, but
+//! `prefix`, `affix`, `suffix`, `unfixable` do not.
+
+use crate::types::extract_conventional_prefix;
+
+/// Conventional Commit prefixes that indicate a bug fix.
+const FIX_PREFIXES: &[&str] = &["fix", "bugfix", "hotfix", "patch", "revert"];
+
+/// Whole-word keywords (case-insensitive) that indicate a fix when they
+/// appear anywhere in the subject. Order is irrelevant; matching is O(n)
+/// per subject which is fine for commit-log-sized inputs.
+const SUBJECT_KEYWORDS: &[&str] = &[
+    "fix",
+    "fixed",
+    "fixes",
+    "fixing",
+    "bug",
+    "bugfix",
+    "hotfix",
+    "patch",
+    "patched",
+    "revert",
+    "reverts",
+    "reverted",
+    "regression",
+    "race",
+    "deadlock",
+    "leak",
+    "crash",
+    "crashed",
+    "oops",
+    "typo",
+    "mistake",
+    "broken",
+];
+
+/// Issue-closure verbs that GitHub/GitLab recognize. Followed by `#NNN`
+/// or `GH-NNN` in the same subject, this is a strong fix signal.
+const CLOSURE_VERBS: &[&str] = &[
+    "fix", "fixes", "fixed", "close", "closes", "closed", "resolve", "resolves", "resolved",
+];
+
+/// Returns `true` if the commit subject looks like a bug fix.
+pub fn is_bug_fix(subject: &str) -> bool {
+    if subject.trim().is_empty() {
+        return false;
+    }
+
+    if let Some(prefix) = extract_conventional_prefix(subject) {
+        if FIX_PREFIXES.contains(&prefix.as_str()) {
+            return true;
+        }
+    }
+
+    let lower = subject.to_ascii_lowercase();
+
+    if has_issue_closure(&lower) {
+        return true;
+    }
+
+    contains_keyword(&lower)
+}
+
+fn contains_keyword(lower_subject: &str) -> bool {
+    for kw in SUBJECT_KEYWORDS {
+        if find_word(lower_subject, kw) {
+            return true;
+        }
+    }
+    false
+}
+
+fn has_issue_closure(lower_subject: &str) -> bool {
+    for verb in CLOSURE_VERBS {
+        let mut start = 0usize;
+        while let Some(pos) = lower_subject[start..].find(verb) {
+            let abs = start + pos;
+            let end = abs + verb.len();
+            let left_ok = abs == 0 || !is_word_char(lower_subject.as_bytes()[abs - 1]);
+            let right_ok =
+                end == lower_subject.len() || !is_word_char(lower_subject.as_bytes()[end]);
+            if left_ok && right_ok && followed_by_issue_ref(&lower_subject[end..]) {
+                return true;
+            }
+            start = abs + 1;
+        }
+    }
+    false
+}
+
+fn followed_by_issue_ref(rest: &str) -> bool {
+    // Allow optional `:` and whitespace, then either `#NNN`, `gh-NNN`, or
+    // `<owner>/<repo>#NNN`. We only need a quick check, not a full parser.
+    let trimmed = rest.trim_start_matches([':', ' ', '\t']);
+    let bytes = trimmed.as_bytes();
+
+    // Skip an optional `<word>/<word>` prefix (cross-repo references).
+    let mut idx = 0;
+    while idx < bytes.len()
+        && (bytes[idx].is_ascii_alphanumeric()
+            || bytes[idx] == b'-'
+            || bytes[idx] == b'_'
+            || bytes[idx] == b'/')
+    {
+        idx += 1;
+    }
+    let after_org = if idx > 0 && idx < bytes.len() && bytes[idx - 1] == b'/' {
+        &trimmed[idx..]
+    } else {
+        trimmed
+    };
+    let bytes = after_org.as_bytes();
+
+    if bytes.starts_with(b"#") && bytes.len() > 1 && bytes[1].is_ascii_digit() {
+        return true;
+    }
+    if (bytes.starts_with(b"gh-") || bytes.starts_with(b"GH-"))
+        && bytes.len() > 3
+        && bytes[3].is_ascii_digit()
+    {
+        return true;
+    }
+    false
+}
+
+fn find_word(haystack: &str, needle: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    if needle_bytes.is_empty() || needle_bytes.len() > bytes.len() {
+        return false;
+    }
+    let mut start = 0;
+    while let Some(pos) = haystack[start..].find(needle) {
+        let abs = start + pos;
+        let end = abs + needle.len();
+        let left_ok = abs == 0 || !is_word_char(bytes[abs - 1]);
+        let right_ok = end == bytes.len() || !is_word_char(bytes[end]);
+        if left_ok && right_ok {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
+fn is_word_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conventional_fix_prefix_hits() {
+        assert!(is_bug_fix("fix: handle null pointer"));
+        assert!(is_bug_fix("fix(core): retry on timeout"));
+        assert!(is_bug_fix("fix!: drop deprecated API"));
+        assert!(is_bug_fix("bugfix: off-by-one in loop"));
+        assert!(is_bug_fix("hotfix: revert bad migration"));
+        assert!(is_bug_fix("patch: clamp out-of-range value"));
+        assert!(is_bug_fix("revert: \"feat: thing\""));
+    }
+
+    #[test]
+    fn non_fix_conventional_prefixes_skip() {
+        assert!(!is_bug_fix("feat: add login flow"));
+        assert!(!is_bug_fix("docs: update README"));
+        assert!(!is_bug_fix("chore(deps): bump tokio to 1.40"));
+        assert!(!is_bug_fix("refactor: extract helper"));
+        assert!(!is_bug_fix("style: cargo fmt"));
+        assert!(!is_bug_fix("test: cover edge case"));
+    }
+
+    #[test]
+    fn freeform_keywords_hit() {
+        assert!(is_bug_fix("Fix crash when parsing empty input"));
+        assert!(is_bug_fix("Fixed a race in the worker pool"));
+        assert!(is_bug_fix("Fixes deadlock during shutdown"));
+        assert!(is_bug_fix("FIXES the broken handler"));
+        assert!(is_bug_fix("Bug in token refresh loop"));
+        assert!(is_bug_fix("Hotfix for prod outage"));
+        assert!(is_bug_fix("revert sketchy commit"));
+        assert!(is_bug_fix("regression: pagination off-by-one"));
+        assert!(is_bug_fix("Memory leak in cache eviction"));
+        assert!(is_bug_fix("Oops, wrong path"));
+        assert!(is_bug_fix("typo in error message"));
+    }
+
+    #[test]
+    fn fix_inside_other_words_does_not_hit() {
+        // The classic false-positive set: substring matches that are not fixes.
+        assert!(!is_bug_fix("Add prefix support to parser"));
+        assert!(!is_bug_fix("Refactor suffix handling"));
+        assert!(!is_bug_fix("Affix label to the message"));
+        assert!(!is_bug_fix("Document unfixable edge cases"));
+        assert!(!is_bug_fix("feat: postfix evaluation"));
+    }
+
+    #[test]
+    fn issue_closure_phrases_hit() {
+        assert!(is_bug_fix("Fixes #123"));
+        assert!(is_bug_fix("Closes #42 via the new retry path"));
+        assert!(is_bug_fix("Resolves GH-7"));
+        assert!(is_bug_fix("Fix: resolves agent-sh/agnix#900"));
+        assert!(is_bug_fix("close #1"));
+    }
+
+    #[test]
+    fn empty_or_whitespace_subject_is_not_a_fix() {
+        assert!(!is_bug_fix(""));
+        assert!(!is_bug_fix("   "));
+        assert!(!is_bug_fix("\t\n"));
+    }
+
+    #[test]
+    fn mixed_case_keywords_hit() {
+        assert!(is_bug_fix("FIX broken handler"));
+        assert!(is_bug_fix("BUG in pagination"));
+        assert!(is_bug_fix("REGRESSION from yesterday"));
+    }
+
+    #[test]
+    fn close_without_issue_ref_does_not_hit() {
+        // "close" alone is too generic - must be followed by an issue ref
+        // to count as a fix. (We do not want "close the modal" to register.)
+        assert!(!is_bug_fix("Close the modal on ESC"));
+        assert!(!is_bug_fix("Resolves the open question"));
+    }
+}

--- a/crates/analyzer-core/src/lib.rs
+++ b/crates/analyzer-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Shared types, git2 wrapper, file walking, and JSON output for agent-analyzer.
 
 pub mod bot_detect;
+pub mod bug_fix_detect;
 pub mod git;
 pub mod output;
 pub mod types;

--- a/crates/analyzer-git-map/src/aggregator.rs
+++ b/crates/analyzer-git-map/src/aggregator.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 
 use analyzer_core::bot_detect::is_bot;
+use analyzer_core::bug_fix_detect::is_bug_fix;
 use analyzer_core::types::{
     CommitDelta, Contributors, ConventionInfo, FileActivity, GitInfo, Releases, RepoIntelData,
     extract_conventional_prefix,
@@ -149,7 +150,7 @@ pub fn merge_delta(map: &mut RepoIntelData, delta: &CommitDelta) {
                 entry.authors.push(commit.author_name.clone());
             }
 
-            if prefix.as_deref() == Some("fix") {
+            if is_bug_fix(&commit.subject) {
                 entry.bug_fix_changes += 1;
                 if commit.date > entry.last_bug_fix {
                     entry.last_bug_fix.clone_from(&commit.date);
@@ -361,6 +362,38 @@ mod tests {
 
         assert_eq!(map.conventions.prefixes["feat"], 2);
         assert_eq!(map.conventions.prefixes["fix"], 1);
+    }
+
+    #[test]
+    fn test_merge_delta_bug_fix_counts_freeform_subjects() {
+        // Verifies the broader bug-fix detection: subjects without a `fix:`
+        // prefix still count as bug fixes when they use fix-related keywords
+        // or issue-closure phrases. The pre-broadening aggregator would have
+        // counted only the explicit `fix:` commit here.
+        let mut map = create_empty_map();
+        let file = || {
+            vec![FileChange {
+                path: "src/lib.rs".to_string(),
+                additions: 1,
+                deletions: 1,
+            }]
+        };
+        let delta = make_delta(vec![
+            make_commit("alice", "fix: explicit conventional fix", file()),
+            make_commit("alice", "Fix race condition in worker pool", file()),
+            make_commit("alice", "Resolves #42", file()),
+            make_commit("alice", "hotfix for prod outage", file()),
+            make_commit("alice", "feat: add login flow", file()),
+            make_commit("alice", "Add prefix support to parser", file()),
+        ]);
+
+        merge_delta(&mut map, &delta);
+
+        let activity = &map.file_activity["src/lib.rs"];
+        assert_eq!(
+            activity.bug_fix_changes, 4,
+            "expected 4 bug-fix commits (conventional + race + resolves + hotfix)"
+        );
     }
 
     #[test]

--- a/crates/analyzer-git-map/src/aggregator.rs
+++ b/crates/analyzer-git-map/src/aggregator.rs
@@ -383,6 +383,9 @@ mod tests {
             make_commit("alice", "Fix race condition in worker pool", file()),
             make_commit("alice", "Resolves #42", file()),
             make_commit("alice", "hotfix for prod outage", file()),
+            // Cross-repo issue closure with no fix-related keyword in
+            // the subject - exercises the <owner>/<repo>#NNN branch.
+            make_commit("alice", "Closes agent-sh/agnix#900", file()),
             make_commit("alice", "feat: add login flow", file()),
             make_commit("alice", "Add prefix support to parser", file()),
         ]);
@@ -391,8 +394,8 @@ mod tests {
 
         let activity = &map.file_activity["src/lib.rs"];
         assert_eq!(
-            activity.bug_fix_changes, 4,
-            "expected 4 bug-fix commits (conventional + race + resolves + hotfix)"
+            activity.bug_fix_changes, 5,
+            "expected 5 bug-fix commits (conventional + race + resolves + hotfix + cross-repo)"
         );
     }
 


### PR DESCRIPTION
## Why

`bug_fix_changes` was previously incremented only when a commit subject started with `fix:`. That misses every project that does not enforce Conventional Commits, plus several repos that *do* use it but file regressions under different verbs - "Fix race", "Hotfix for prod outage", "Resolves #42", "revert sketchy commit", etc. On agnix this under-counted bug-fix activity even though the commit history is full of plain English fix subjects.

## What changes

New `analyzer-core::bug_fix_detect` module with one public function, `is_bug_fix(subject)`, wired into the aggregator in place of the prefix-only check.

Heuristic returns `true` when **any** of:

1. **Conventional Commit prefix** is one of `fix`, `bugfix`, `hotfix`, `patch`, `revert` (so `patch:`, `revert:`, and `hotfix:` now also count).
2. **Subject contains a fix-related whole-word keyword** (case-insensitive): `fix`, `fixed`, `fixes`, `fixing`, `bug`, `bugfix`, `hotfix`, `patch`, `patched`, `revert`, `reverts`, `reverted`, `regression`, `race`, `deadlock`, `leak`, `crash`, `crashed`, `oops`, `typo`, `mistake`, `broken`.
3. **Subject contains an issue-closure phrase**: `fixes #123`, `closes #42`, `resolves GH-7`, `resolves owner/repo#900`.

## False-positive guard

Matching is whole-word (case-insensitive), so `prefix`, `suffix`, `affix`, `postfix`, `unfixable` do **not** register. `close` without an issue ref also does not register, so `Close the modal on ESC` stays out.

## Tests

- 16 new unit tests in `bug_fix_detect.rs` cover every branch (positives, negatives, mixed case, issue-closure variants, the false-positive set).
- 1 new aggregator-level test confirms the wired path counts plain-English fix subjects against `bug_fix_changes`.

## What this affects downstream

- `bugspots` query density rises for repos that don't use `fix:`
- `file_activity.bug_fix_changes` and `last_bug_fix` become more accurate
- diff-risk's `bug_fix_rate` term gets a more honest denominator

## Test plan

- [x] `cargo test --workspace` - 178 tests pass (was 162)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` - clean
- [x] `cargo fmt --all` - clean
- [ ] CI green on PR

## Independence

Stacks cleanly with #17 (drop-AI-detection) - the two PRs touch different code paths and either order works. They can land in any order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the definition of what counts as a bug-fix commit, which will alter downstream metrics (`bug_fix_changes`, `last_bug_fix`, and any derived scores) and could introduce false positives/negatives despite added tests.
> 
> **Overview**
> Improves bug-fix attribution by replacing the aggregator’s strict `prefix == "fix"` check with a new heuristic `is_bug_fix()` matcher.
> 
> The new detection counts fixes not only via Conventional Commit prefixes (e.g. `fix`, `hotfix`, `revert`, `patch`) but also via whole-word fix keywords and issue-closure phrases (e.g. `closes #42`, `resolves GH-7`), with tests added for boundary/false-positive cases and an aggregator-level test to ensure freeform subjects increment `bug_fix_changes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7056eee6e1afea1fbb1c97af579f5358d1947f13. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->