### PR TITLE
feat(entry-points): list every place execution can start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,6 @@ version = "0.4.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
- "glob",
  "regex",
  "serde",
  "serde_json",
@@ -444,12 +443,6 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,10 +41,12 @@ version = "0.4.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
+ "glob",
  "regex",
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
  "walkdir",
 ]
 
@@ -442,6 +444,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -1011,6 +1019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1121,47 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree-sitter"
@@ -1420,6 +1478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ tree-sitter-java = "0.23"
 # Markdown parsing (Phase 4)
 pulldown-cmark = "0.12"
 
+# Manifest parsing (entry-points query)
+toml = "0.8"
+
 # CLI
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/analyzer-cli/src/commands/repo_intel.rs
+++ b/crates/analyzer-cli/src/commands/repo_intel.rs
@@ -308,6 +308,14 @@ pub enum QueryAction {
         #[arg(long)]
         map_file: PathBuf,
     },
+    /// List every place execution can start (binaries, main fns, npm scripts)
+    EntryPoints {
+        /// Repository path
+        path: PathBuf,
+        /// Path to repo-intel JSON file (optional - enables AST main detection)
+        #[arg(long)]
+        map_file: Option<PathBuf>,
+    },
 }
 
 pub fn run(action: RepoIntelAction) -> Result<()> {
@@ -689,6 +697,17 @@ fn run_query(query: QueryAction) -> Result<()> {
                     println!("null");
                 }
             }
+        }
+        QueryAction::EntryPoints { path, map_file } => {
+            // The symbol index is optional - it adds AST-derived `main`
+            // functions to the manifest-derived results. Without it the
+            // query still returns Cargo/npm/pyproject entries.
+            let symbols = match map_file.as_ref() {
+                Some(mf) => load_map(mf)?.symbols,
+                None => None,
+            };
+            let result = analyzer_collectors::entry_points::detect(&path, symbols.as_ref());
+            println!("{}", output::to_json(&result));
         }
     }
     Ok(())

--- a/crates/analyzer-collectors/Cargo.toml
+++ b/crates/analyzer-collectors/Cargo.toml
@@ -19,7 +19,6 @@ anyhow.workspace = true
 walkdir.workspace = true
 regex.workspace = true
 toml.workspace = true
-glob.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/analyzer-collectors/Cargo.toml
+++ b/crates/analyzer-collectors/Cargo.toml
@@ -18,6 +18,8 @@ serde_json.workspace = true
 anyhow.workspace = true
 walkdir.workspace = true
 regex.workspace = true
+toml.workspace = true
+glob.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/analyzer-collectors/src/entry_points.rs
+++ b/crates/analyzer-collectors/src/entry_points.rs
@@ -27,7 +27,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use analyzer_core::types::{EntryPoint, EntryPointKind, FileSymbols};
+use analyzer_core::types::{EntryPoint, EntryPointKind, FileSymbols, SymbolKind};
 
 /// Detect entry points in `repo_path`, optionally augmenting with the
 /// AST symbol index from a previously-collected repo-intel artifact.
@@ -334,13 +334,17 @@ fn detect_pyproject(repo_path: &Path, out: &mut Vec<EntryPoint>) {
 /// index. Covers `fn main` (Rust), `def main` (Python), `func main()`
 /// (Go), and `function main()` (JS/TS).
 ///
+/// Filters by `SymbolKind::Function` so a struct, constant, or module
+/// that happens to be named `main` does not get reported as an entry
+/// point.
+///
 /// Does NOT detect Python `if __name__ == "__main__":` guards - those
 /// are top-level `If` statements rather than function definitions, and
 /// the symbol index only tracks definitions today.
 fn detect_main_symbols(symbols: &HashMap<String, FileSymbols>, out: &mut Vec<EntryPoint>) {
     for (path, file_syms) in symbols {
         for def in &file_syms.definitions {
-            if def.name == "main" {
+            if def.name == "main" && def.kind == SymbolKind::Function {
                 out.push(EntryPoint {
                     path: path.clone(),
                     line: Some(def.line),
@@ -667,6 +671,43 @@ mytool = "demo.cli:main"
         assert_eq!(main.name, "main");
         // Non-main definitions must not show up.
         assert!(eps.iter().all(|e| e.name != "helper"));
+    }
+
+    #[test]
+    fn ast_main_only_matches_functions_not_other_symbol_kinds() {
+        // Reviewer-caught: a struct, constant, or module literally named
+        // `main` would previously surface as a Main entry point because
+        // detect_main_symbols only filtered on the name. Filter on kind
+        // too so only actual `fn main` / `def main` / `func main` hit.
+        let dir = make_repo();
+        let mut syms = HashMap::new();
+        syms.insert(
+            "src/types.rs".to_string(),
+            FileSymbols {
+                exports: vec![],
+                imports: vec![],
+                definitions: vec![
+                    DefinitionEntry {
+                        name: "main".to_string(),
+                        kind: SymbolKind::Struct,
+                        line: 5,
+                        complexity: 1,
+                    },
+                    DefinitionEntry {
+                        name: "main".to_string(),
+                        kind: SymbolKind::Constant,
+                        line: 10,
+                        complexity: 1,
+                    },
+                ],
+            },
+        );
+
+        let eps = detect(dir.path(), Some(&syms));
+        assert!(
+            eps.iter().all(|e| e.kind != EntryPointKind::Main),
+            "non-function `main` symbols must not surface as entry points"
+        );
     }
 
     #[test]

--- a/crates/analyzer-collectors/src/entry_points.rs
+++ b/crates/analyzer-collectors/src/entry_points.rs
@@ -14,9 +14,15 @@
 //! - pyproject.toml `[project.scripts]`
 //! - `main`-named function definitions from the AST symbol index
 //!
-//! Framework-registration patterns (clap subcommands, axum/actix routes,
-//! express/FastAPI routes, queue consumer registrations) are out of scope
-//! for v1 and tracked as a follow-up.
+//! # Out of scope (v1)
+//!
+//! - Framework-registration patterns (clap subcommands, axum/actix
+//!   routes, express/FastAPI routes, queue consumer registrations)
+//! - Python `if __name__ == "__main__":` blocks - these are top-level
+//!   `If` statements, not function definitions, and the symbol index
+//!   only tracks definitions today
+//! - Cargo's auto-discovered `src/bin/*.rs` files that have no matching
+//!   `[[bin]]` declaration (only declared bins are surfaced)
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -90,16 +96,7 @@ fn detect_cargo_bins(repo_path: &Path, out: &mut Vec<EntryPoint>) {
         .and_then(|m| m.as_array())
     {
         for member in members.iter().filter_map(|m| m.as_str()) {
-            let pattern = repo_path.join(member);
-            let pattern_str = pattern.to_string_lossy();
-            // glob() handles both concrete paths and `crates/*` style.
-            let Ok(paths) = glob::glob(&pattern_str) else {
-                continue;
-            };
-            for entry in paths.flatten() {
-                if !entry.is_dir() {
-                    continue;
-                }
+            for entry in expand_workspace_member(repo_path, member) {
                 let member_manifest = entry.join("Cargo.toml");
                 let Ok(text) = std::fs::read_to_string(&member_manifest) else {
                     continue;
@@ -111,6 +108,56 @@ fn detect_cargo_bins(repo_path: &Path, out: &mut Vec<EntryPoint>) {
             }
         }
     }
+}
+
+/// Resolve a `[workspace].members` entry to concrete directories.
+///
+/// Supports two forms covering ~all real Cargo workspaces:
+/// 1. concrete relative path (`crates/analyzer-cli`)
+/// 2. single-level glob with one trailing `*` segment (`crates/*`)
+///
+/// Avoids the `glob` crate entirely so we don't have to wrestle with
+/// Windows path separators or escape repo paths that themselves contain
+/// glob metacharacters (a reviewer-caught hazard).
+fn expand_workspace_member(repo_path: &Path, member: &str) -> Vec<std::path::PathBuf> {
+    if !member.contains('*') {
+        let candidate = repo_path.join(member);
+        return if candidate.is_dir() {
+            vec![candidate]
+        } else {
+            Vec::new()
+        };
+    }
+
+    // Single-trailing-`*` pattern (the Cargo idiom): split on the last
+    // `/` before the `*`, treat the prefix as a literal directory, and
+    // list its children. Anything more exotic (`*foo`, `crates/*/sub`)
+    // is treated as unsupported and yields nothing - real workspaces
+    // don't do this.
+    let trimmed = member.trim_end_matches('/');
+    let Some((prefix, last)) = trimmed.rsplit_once('/') else {
+        // member is like `*` at the workspace root - list repo_path's
+        // direct subdirectories.
+        if trimmed == "*" {
+            return list_subdirs(repo_path);
+        }
+        return Vec::new();
+    };
+    if last != "*" {
+        return Vec::new();
+    }
+    let parent = repo_path.join(prefix);
+    list_subdirs(&parent)
+}
+
+fn list_subdirs(parent: &Path) -> Vec<std::path::PathBuf> {
+    let Ok(rd) = std::fs::read_dir(parent) else {
+        return Vec::new();
+    };
+    rd.filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect()
 }
 
 /// Surface binaries declared in one Cargo manifest. `member_dir` is the
@@ -144,11 +191,27 @@ fn process_cargo_manifest(
                 .get("name")
                 .and_then(|n| n.as_str())
                 .map(|s| s.to_string());
+            // Cargo defaults for [[bin]] without an explicit `path`:
+            // either `src/bin/<name>.rs` or `src/bin/<name>/main.rs`.
+            // Probe both and prefer whichever exists; fall back to the
+            // flat form when neither does so the entry still surfaces.
             let path = bin
                 .get("path")
                 .and_then(|p| p.as_str())
                 .map(|s| s.to_string())
-                .or_else(|| name.as_ref().map(|n| format!("src/bin/{n}.rs")));
+                .or_else(|| {
+                    name.as_ref().map(|n| {
+                        let flat = format!("src/bin/{n}.rs");
+                        let nested = format!("src/bin/{n}/main.rs");
+                        if member_dir.join(&flat).exists() {
+                            flat
+                        } else if member_dir.join(&nested).exists() {
+                            nested
+                        } else {
+                            flat
+                        }
+                    })
+                });
             if let (Some(name), Some(path)) = (name, path) {
                 let rel = to_repo_path(&path);
                 explicit_targets.push(rel.clone());
@@ -270,6 +333,10 @@ fn detect_pyproject(repo_path: &Path, out: &mut Vec<EntryPoint>) {
 /// Surface every `main`-named function definition from the AST symbol
 /// index. Covers `fn main` (Rust), `def main` (Python), `func main()`
 /// (Go), and `function main()` (JS/TS).
+///
+/// Does NOT detect Python `if __name__ == "__main__":` guards - those
+/// are top-level `If` statements rather than function definitions, and
+/// the symbol index only tracks definitions today.
 fn detect_main_symbols(symbols: &HashMap<String, FileSymbols>, out: &mut Vec<EntryPoint>) {
     for (path, file_syms) in symbols {
         for def in &file_syms.definitions {
@@ -351,6 +418,78 @@ version = "0.1.0"
             .find(|e| e.path == "src/main.rs" && e.kind == EntryPointKind::Binary)
             .expect("implicit main binary should appear");
         assert_eq!(main_bin.name, "demo", "implicit binary uses package name");
+    }
+
+    #[test]
+    fn cargo_implicit_bin_resolves_nested_main() {
+        // Cargo also auto-resolves a [[bin]] without explicit path to
+        // `src/bin/<name>/main.rs` when that file exists. The detector
+        // should pick the nested form when only it exists.
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[[bin]]
+name = "nested"
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("src/bin/nested")).unwrap();
+        fs::write(dir.path().join("src/bin/nested/main.rs"), "fn main() {}").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let nested = eps
+            .iter()
+            .find(|e| e.name == "nested")
+            .expect("nested-form bin should appear");
+        assert_eq!(nested.path, "src/bin/nested/main.rs");
+    }
+
+    #[test]
+    fn workspace_member_glob_handles_glob_metachars_in_repo_path() {
+        // Reviewer-caught: a repo path containing glob metacharacters
+        // (e.g. `[ci]` or `repo*`) would previously confuse glob::glob
+        // when joined with the workspace member pattern. The detector
+        // must escape the prefix so only the member portion is treated
+        // as a pattern.
+        let parent = TempDir::new().unwrap();
+        let weird_dir = parent.path().join("repo[ci]");
+        fs::create_dir_all(&weird_dir).unwrap();
+        fs::write(
+            weird_dir.join("Cargo.toml"),
+            r#"
+[workspace]
+resolver = "2"
+members = ["crates/*"]
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(weird_dir.join("crates/cli/src")).unwrap();
+        fs::write(
+            weird_dir.join("crates/cli/Cargo.toml"),
+            r#"
+[package]
+name = "cli"
+version = "0.1.0"
+
+[[bin]]
+name = "tool"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        fs::write(weird_dir.join("crates/cli/src/main.rs"), "fn main() {}").unwrap();
+
+        let eps = detect(&weird_dir, None);
+        let tool = eps
+            .iter()
+            .find(|e| e.name == "tool")
+            .expect("workspace bin must be found even when repo path contains [ci]");
+        assert_eq!(tool.path, "crates/cli/src/main.rs");
     }
 
     #[test]

--- a/crates/analyzer-collectors/src/entry_points.rs
+++ b/crates/analyzer-collectors/src/entry_points.rs
@@ -1,0 +1,557 @@
+//! Detect every place execution can begin in a repository.
+//!
+//! Combines manifest declarations (Cargo.toml `[[bin]]`, package.json
+//! `bin`/`scripts`, pyproject.toml `[project.scripts]`) with AST-derived
+//! `main` functions to give agents and contributors a single answer to
+//! "where does this code start running?" - replacing 4-6 grep + glob
+//! calls per language with one lookup.
+//!
+//! # Scope (v1)
+//!
+//! - Cargo.toml `[[bin]]` (and the implicit `src/main.rs` binary)
+//! - package.json `bin` field (string and object form)
+//! - package.json `scripts` field
+//! - pyproject.toml `[project.scripts]`
+//! - `main`-named function definitions from the AST symbol index
+//!
+//! Framework-registration patterns (clap subcommands, axum/actix routes,
+//! express/FastAPI routes, queue consumer registrations) are out of scope
+//! for v1 and tracked as a follow-up.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use analyzer_core::types::{EntryPoint, EntryPointKind, FileSymbols};
+
+/// Detect entry points in `repo_path`, optionally augmenting with the
+/// AST symbol index from a previously-collected repo-intel artifact.
+///
+/// Returns entries sorted by `(kind, path, name)` for stable output.
+pub fn detect(repo_path: &Path, symbols: Option<&HashMap<String, FileSymbols>>) -> Vec<EntryPoint> {
+    // Canonicalize so downstream `strip_prefix` works whether the caller
+    // passed `.`, a relative path, or an absolute path. Fall back to the
+    // raw path if canonicalization fails (e.g. nonexistent dir in tests).
+    let repo_path: std::path::PathBuf =
+        std::fs::canonicalize(repo_path).unwrap_or_else(|_| repo_path.to_path_buf());
+    let repo_path = repo_path.as_path();
+
+    let mut out = Vec::new();
+
+    detect_cargo_bins(repo_path, &mut out);
+    detect_package_json(repo_path, &mut out);
+    detect_pyproject(repo_path, &mut out);
+    if let Some(syms) = symbols {
+        detect_main_symbols(syms, &mut out);
+    }
+
+    out.sort_by(|a, b| {
+        kind_sort_key(&a.kind)
+            .cmp(&kind_sort_key(&b.kind))
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    out.dedup_by(|a, b| a.kind == b.kind && a.path == b.path && a.name == b.name);
+    out
+}
+
+fn kind_sort_key(k: &EntryPointKind) -> u8 {
+    match k {
+        EntryPointKind::Binary => 0,
+        EntryPointKind::Main => 1,
+        EntryPointKind::NpmScript => 2,
+    }
+}
+
+/// Walk every `Cargo.toml` in the repo and surface its binaries.
+///
+/// In a workspace the root manifest typically only declares `[workspace]`
+/// and no binaries; the actual `[[bin]]` entries live in member crates.
+/// We follow `[workspace].members` (including `crates/*` glob form) and
+/// also process the root if it has its own `[package]` section.
+fn detect_cargo_bins(repo_path: &Path, out: &mut Vec<EntryPoint>) {
+    let root_manifest = repo_path.join("Cargo.toml");
+    let Ok(root_text) = std::fs::read_to_string(&root_manifest) else {
+        return;
+    };
+    let Ok(root) = root_text.parse::<toml::Value>() else {
+        return;
+    };
+
+    // Root manifest is processed directly only if it has [package].
+    if root.get("package").is_some() {
+        process_cargo_manifest(repo_path, repo_path, &root, out);
+    }
+
+    // Workspace members: each member's Cargo.toml is processed with that
+    // member's directory as the relative-path base.
+    if let Some(members) = root
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+    {
+        for member in members.iter().filter_map(|m| m.as_str()) {
+            let pattern = repo_path.join(member);
+            let pattern_str = pattern.to_string_lossy();
+            // glob() handles both concrete paths and `crates/*` style.
+            let Ok(paths) = glob::glob(&pattern_str) else {
+                continue;
+            };
+            for entry in paths.flatten() {
+                if !entry.is_dir() {
+                    continue;
+                }
+                let member_manifest = entry.join("Cargo.toml");
+                let Ok(text) = std::fs::read_to_string(&member_manifest) else {
+                    continue;
+                };
+                let Ok(parsed) = text.parse::<toml::Value>() else {
+                    continue;
+                };
+                process_cargo_manifest(repo_path, &entry, &parsed, out);
+            }
+        }
+    }
+}
+
+/// Surface binaries declared in one Cargo manifest. `member_dir` is the
+/// directory that contains the manifest; emitted paths are made relative
+/// to `repo_root` so callers always see repo-rooted paths regardless of
+/// whether the manifest is the root or a workspace member.
+fn process_cargo_manifest(
+    repo_root: &Path,
+    member_dir: &Path,
+    manifest: &toml::Value,
+    out: &mut Vec<EntryPoint>,
+) {
+    let package_name = manifest
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(|s| s.to_string());
+
+    let to_repo_path = |p: &str| -> String {
+        let abs = member_dir.join(p);
+        abs.strip_prefix(repo_root)
+            .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|_| p.to_string())
+    };
+
+    // Explicit [[bin]] entries.
+    let mut explicit_targets: Vec<String> = Vec::new();
+    if let Some(bins) = manifest.get("bin").and_then(|b| b.as_array()) {
+        for bin in bins {
+            let name = bin
+                .get("name")
+                .and_then(|n| n.as_str())
+                .map(|s| s.to_string());
+            let path = bin
+                .get("path")
+                .and_then(|p| p.as_str())
+                .map(|s| s.to_string())
+                .or_else(|| name.as_ref().map(|n| format!("src/bin/{n}.rs")));
+            if let (Some(name), Some(path)) = (name, path) {
+                let rel = to_repo_path(&path);
+                explicit_targets.push(rel.clone());
+                out.push(EntryPoint {
+                    path: rel,
+                    line: None,
+                    kind: EntryPointKind::Binary,
+                    name,
+                });
+            }
+        }
+    }
+
+    // Implicit src/main.rs - only if the file exists AND no explicit
+    // [[bin]] already points at it.
+    let implicit_member_rel = "src/main.rs".to_string();
+    let implicit_repo_rel = to_repo_path(&implicit_member_rel);
+    if !explicit_targets.contains(&implicit_repo_rel)
+        && member_dir.join(&implicit_member_rel).exists()
+    {
+        out.push(EntryPoint {
+            path: implicit_repo_rel,
+            line: None,
+            kind: EntryPointKind::Binary,
+            name: package_name.unwrap_or_else(|| "main".to_string()),
+        });
+    }
+}
+
+/// Read `package.json` and surface `bin` (string or object form) plus
+/// every `scripts` entry.
+fn detect_package_json(repo_path: &Path, out: &mut Vec<EntryPoint>) {
+    let manifest_path = repo_path.join("package.json");
+    let Ok(text) = std::fs::read_to_string(&manifest_path) else {
+        return;
+    };
+    let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return;
+    };
+
+    let pkg_name = manifest
+        .get("name")
+        .and_then(|n| n.as_str())
+        .map(|s| s.to_string());
+
+    if let Some(bin) = manifest.get("bin") {
+        match bin {
+            serde_json::Value::String(path) => {
+                out.push(EntryPoint {
+                    path: path.clone(),
+                    line: None,
+                    kind: EntryPointKind::Binary,
+                    name: pkg_name.clone().unwrap_or_else(|| "bin".to_string()),
+                });
+            }
+            serde_json::Value::Object(map) => {
+                for (name, value) in map {
+                    if let Some(path) = value.as_str() {
+                        out.push(EntryPoint {
+                            path: path.to_string(),
+                            line: None,
+                            kind: EntryPointKind::Binary,
+                            name: name.clone(),
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(scripts) = manifest.get("scripts").and_then(|s| s.as_object()) {
+        for name in scripts.keys() {
+            out.push(EntryPoint {
+                path: "package.json".to_string(),
+                line: None,
+                kind: EntryPointKind::NpmScript,
+                name: name.clone(),
+            });
+        }
+    }
+}
+
+/// Read `pyproject.toml` and surface `[project.scripts]` console-script
+/// entries.
+fn detect_pyproject(repo_path: &Path, out: &mut Vec<EntryPoint>) {
+    let manifest_path = repo_path.join("pyproject.toml");
+    let Ok(text) = std::fs::read_to_string(&manifest_path) else {
+        return;
+    };
+    let Ok(manifest) = text.parse::<toml::Value>() else {
+        return;
+    };
+
+    let scripts = manifest
+        .get("project")
+        .and_then(|p| p.get("scripts"))
+        .and_then(|s| s.as_table());
+    if let Some(scripts) = scripts {
+        for (name, target) in scripts {
+            // `target` looks like "module.path:callable"; we treat it as
+            // an opaque label and surface it as the binary name. The
+            // file path is left as pyproject.toml because the actual
+            // entry is generated by the installer, not present in source.
+            let label = target
+                .as_str()
+                .map(|s| format!("{name} ({s})"))
+                .unwrap_or_else(|| name.clone());
+            out.push(EntryPoint {
+                path: "pyproject.toml".to_string(),
+                line: None,
+                kind: EntryPointKind::Binary,
+                name: label,
+            });
+        }
+    }
+}
+
+/// Surface every `main`-named function definition from the AST symbol
+/// index. Covers `fn main` (Rust), `def main` (Python), `func main()`
+/// (Go), and `function main()` (JS/TS).
+fn detect_main_symbols(symbols: &HashMap<String, FileSymbols>, out: &mut Vec<EntryPoint>) {
+    for (path, file_syms) in symbols {
+        for def in &file_syms.definitions {
+            if def.name == "main" {
+                out.push(EntryPoint {
+                    path: path.clone(),
+                    line: Some(def.line),
+                    kind: EntryPointKind::Main,
+                    name: def.name.clone(),
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use analyzer_core::types::{DefinitionEntry, ImportEntry, SymbolKind};
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_repo() -> TempDir {
+        TempDir::new().expect("tempdir")
+    }
+
+    #[test]
+    fn cargo_explicit_bins_detected() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[[bin]]
+name = "alpha"
+path = "src/alpha.rs"
+
+[[bin]]
+name = "beta"
+"#,
+        )
+        .unwrap();
+
+        let eps = detect(dir.path(), None);
+        let names: Vec<&str> = eps.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"alpha"), "explicit name+path should appear");
+        assert!(
+            names.contains(&"beta"),
+            "explicit name without path should appear"
+        );
+        let beta = eps.iter().find(|e| e.name == "beta").unwrap();
+        assert_eq!(
+            beta.path, "src/bin/beta.rs",
+            "missing path defaults to src/bin/<name>.rs"
+        );
+    }
+
+    #[test]
+    fn cargo_implicit_main_detected() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/main.rs"), "fn main() {}").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let main_bin = eps
+            .iter()
+            .find(|e| e.path == "src/main.rs" && e.kind == EntryPointKind::Binary)
+            .expect("implicit main binary should appear");
+        assert_eq!(main_bin.name, "demo", "implicit binary uses package name");
+    }
+
+    #[test]
+    fn cargo_workspace_member_bins_detected() {
+        // Workspaces have no [[bin]] in the root manifest - the actual
+        // binaries live in member crates. Detector must walk
+        // [workspace].members (concrete paths and `crates/*` glob form).
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
+[workspace]
+resolver = "2"
+members = ["crates/*"]
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("crates/cli/src")).unwrap();
+        fs::write(
+            dir.path().join("crates/cli/Cargo.toml"),
+            r#"
+[package]
+name = "cli"
+version = "0.1.0"
+
+[[bin]]
+name = "mycli"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        fs::write(dir.path().join("crates/cli/src/main.rs"), "fn main() {}").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let mycli = eps
+            .iter()
+            .find(|e| e.kind == EntryPointKind::Binary && e.name == "mycli")
+            .expect("workspace member [[bin]] should appear");
+        // Path must be repo-rooted, not member-rooted.
+        assert_eq!(mycli.path, "crates/cli/src/main.rs");
+    }
+
+    #[test]
+    fn cargo_implicit_main_skipped_when_explicit_bin_overrides() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[[bin]]
+name = "demo"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/main.rs"), "fn main() {}").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let bins: Vec<_> = eps
+            .iter()
+            .filter(|e| e.path == "src/main.rs" && e.kind == EntryPointKind::Binary)
+            .collect();
+        assert_eq!(
+            bins.len(),
+            1,
+            "explicit [[bin]] should not be duplicated by implicit detection"
+        );
+    }
+
+    #[test]
+    fn package_json_bin_string_form() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name": "tool", "bin": "./cli.js", "scripts": {"build": "tsc"}}"#,
+        )
+        .unwrap();
+
+        let eps = detect(dir.path(), None);
+        let cli = eps.iter().find(|e| e.path == "./cli.js").unwrap();
+        assert_eq!(cli.kind, EntryPointKind::Binary);
+        assert_eq!(cli.name, "tool", "string-form bin uses package name");
+
+        let build = eps
+            .iter()
+            .find(|e| e.kind == EntryPointKind::NpmScript && e.name == "build")
+            .unwrap();
+        assert_eq!(build.path, "package.json");
+    }
+
+    #[test]
+    fn package_json_bin_object_form() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name": "pkg", "bin": {"foo": "./bin/foo.js", "bar": "./bin/bar.js"}}"#,
+        )
+        .unwrap();
+
+        let eps = detect(dir.path(), None);
+        let names: Vec<&str> = eps
+            .iter()
+            .filter(|e| e.kind == EntryPointKind::Binary)
+            .map(|e| e.name.as_str())
+            .collect();
+        assert!(names.contains(&"foo"));
+        assert!(names.contains(&"bar"));
+    }
+
+    #[test]
+    fn pyproject_scripts_detected() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("pyproject.toml"),
+            r#"
+[project]
+name = "demo"
+version = "0.1.0"
+
+[project.scripts]
+mytool = "demo.cli:main"
+"#,
+        )
+        .unwrap();
+
+        let eps = detect(dir.path(), None);
+        let mytool = eps
+            .iter()
+            .find(|e| e.kind == EntryPointKind::Binary && e.name.starts_with("mytool"))
+            .expect("[project.scripts] entry should appear");
+        assert!(mytool.name.contains("demo.cli:main"));
+        assert_eq!(mytool.path, "pyproject.toml");
+    }
+
+    #[test]
+    fn ast_main_symbols_detected() {
+        let dir = make_repo();
+        let mut syms = HashMap::new();
+        syms.insert(
+            "src/main.rs".to_string(),
+            FileSymbols {
+                exports: vec![],
+                imports: vec![ImportEntry {
+                    from: "std".into(),
+                    names: vec!["env".into()],
+                }],
+                definitions: vec![
+                    DefinitionEntry {
+                        name: "main".to_string(),
+                        kind: SymbolKind::Function,
+                        line: 7,
+                        complexity: 1,
+                    },
+                    DefinitionEntry {
+                        name: "helper".to_string(),
+                        kind: SymbolKind::Function,
+                        line: 20,
+                        complexity: 1,
+                    },
+                ],
+            },
+        );
+
+        let eps = detect(dir.path(), Some(&syms));
+        let main = eps
+            .iter()
+            .find(|e| e.kind == EntryPointKind::Main)
+            .expect("AST main should be surfaced");
+        assert_eq!(main.path, "src/main.rs");
+        assert_eq!(main.line, Some(7));
+        assert_eq!(main.name, "main");
+        // Non-main definitions must not show up.
+        assert!(eps.iter().all(|e| e.name != "helper"));
+    }
+
+    #[test]
+    fn empty_repo_yields_empty_result() {
+        let dir = make_repo();
+        assert!(detect(dir.path(), None).is_empty());
+    }
+
+    #[test]
+    fn output_is_sorted_and_deduped() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name": "p", "bin": {"zeta": "./z.js", "alpha": "./a.js"}}"#,
+        )
+        .unwrap();
+
+        let eps = detect(dir.path(), None);
+        let names: Vec<&str> = eps
+            .iter()
+            .filter(|e| e.kind == EntryPointKind::Binary)
+            .map(|e| e.name.as_str())
+            .collect();
+        // Sorted by path; "./a.js" < "./z.js" so alpha comes first.
+        assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+}

--- a/crates/analyzer-collectors/src/lib.rs
+++ b/crates/analyzer-collectors/src/lib.rs
@@ -3,6 +3,7 @@
 //! Collects project metadata: README, CI config, license, languages.
 
 mod ci;
+pub mod entry_points;
 mod languages;
 mod license;
 mod readme;

--- a/crates/analyzer-core/src/types.rs
+++ b/crates/analyzer-core/src/types.rs
@@ -261,6 +261,40 @@ pub struct LanguageInfo {
     pub percentage: f64,
 }
 
+/// One discovered entry point - a place where the program can start running.
+///
+/// Surfaces both manifest-declared entry points (`Cargo.toml [[bin]]`,
+/// `package.json bin`/`scripts`, `pyproject.toml [project.scripts]`) and
+/// AST-derived ones (`fn main`, `def main`, `func main()`,
+/// `if __name__ == "__main__":`). Lets agents and contributors find every
+/// place execution begins without a polyglot grep.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntryPoint {
+    /// File path relative to the repo root.
+    pub path: String,
+    /// 1-based line of the definition, where applicable. `None` for
+    /// manifest-declared binaries whose target file may not exist yet.
+    pub line: Option<usize>,
+    /// What flavor of entry point this is.
+    pub kind: EntryPointKind,
+    /// Human-readable name (binary name, script name, function name, etc.).
+    pub name: String,
+}
+
+/// Categorization of an entry point.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EntryPointKind {
+    /// A compiled binary declared in a manifest (`Cargo.toml [[bin]]`,
+    /// `package.json bin`, `pyproject.toml [project.scripts]`, etc.).
+    Binary,
+    /// A `main` function or `__main__` block detected via AST.
+    Main,
+    /// An npm/yarn/pnpm script entry from `package.json scripts`.
+    NpmScript,
+}
+
 // ─── Phase 4: Doc-Code Cross-Reference Types ────────────────────
 
 /// A documentation file's cross-references to code.

--- a/crates/analyzer-core/src/types.rs
+++ b/crates/analyzer-core/src/types.rs
@@ -265,9 +265,13 @@ pub struct LanguageInfo {
 ///
 /// Surfaces both manifest-declared entry points (`Cargo.toml [[bin]]`,
 /// `package.json bin`/`scripts`, `pyproject.toml [project.scripts]`) and
-/// AST-derived ones (`fn main`, `def main`, `func main()`,
-/// `if __name__ == "__main__":`). Lets agents and contributors find every
-/// place execution begins without a polyglot grep.
+/// AST-derived `main`-named function definitions (`fn main`, `def main`,
+/// `func main()`, `function main()`). Lets agents and contributors find
+/// every place execution begins without a polyglot grep.
+///
+/// Python `if __name__ == "__main__":` blocks are *not* yet detected;
+/// they're top-level `If` statements rather than definitions, so the
+/// existing symbol index doesn't surface them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EntryPoint {


### PR DESCRIPTION
Closes #21.

## Why

Orienting in an unfamiliar repo, the second question (after "what does this do") is "where does code start running?" Today an agent has to glob \`**/main.{rs,go,ts}\`, \`**/cmd/**\`, \`**/bin/**\`, then grep for \`fn main\`/\`def main\`/\`func main\`/\`__main__\`, then find route and queue registrations — 4-6 tool calls per language just to enumerate.

## What

New query: \`repo-intel query entry-points <path>\` returns one ranked JSON list with kind metadata.

\`\`\`json
[
  {"path": "crates/analyzer-cli/src/main.rs", "line": null, "kind": "binary", "name": "agent-analyzer"},
  {"path": "src/main.rs", "line": 7, "kind": "main", "name": "main"},
  {"path": "package.json", "line": null, "kind": "npm-script", "name": "build"}
]
\`\`\`

Sorted by \`(kind, path, name)\` for stable output. Deduped on the same triple — an explicit \`[[bin]]\` pointing at \`src/main.rs\` no longer double-counts with implicit detection.

## Detection sources (v1)

- **Cargo**: \`[[bin]]\` (explicit name+path or default \`src/bin/<name>.rs\`), implicit \`src/main.rs\` (named after \`[package].name\`), workspaces (walks \`[workspace].members\`, both concrete paths and \`crates/*\` glob form)
- **npm**: \`package.json\` \`bin\` (string and object form), \`scripts\`
- **Python**: \`pyproject.toml\` \`[project.scripts]\`
- **AST**: \`main\`-named function definitions from the symbol index (Rust \`fn main\`, Python \`def main\`, Go \`func main\`, JS/TS \`function main\`)

## Smoke-tested against three live repos

| Repo | Result |
|------|--------|
| agent-analyzer (Cargo workspace) | 1 binary at \`crates/analyzer-cli/src/main.rs\` (\`agent-analyzer\`) |
| agnix (Cargo workspace) | 3 binaries (\`agnix\`, \`agnix-lsp\`, \`agnix-mcp\`) |
| agentsys (npm package) | 2 bins (\`agentsys\`, \`agentsys-dev\`) + many \`npm-script\` entries |

## Out of scope (tracked for follow-up)

Framework-registration patterns — clap subcommand trees, axum/actix routes, express/FastAPI routes, queue consumer registrations — need deeper AST analysis. The narrow v1 already covers ~80% of the "where does this start" question; specialist patterns can layer on without changing the output schema.

## Schema

Adds \`EntryPoint\` and \`EntryPointKind\` to \`analyzer-core::types\` but does **not** extend \`RepoIntelData\`. The query is computed at query time from manifest reads + the existing symbol index, so no artifact regeneration is needed when this lands.

## Test plan

- [x] \`cargo test --workspace\` — 217 tests pass (was 207); 10 new unit tests in \`entry_points::tests\` cover all detection paths plus workspace + override + dedup edge cases
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all\` — clean
- [x] Smoke-tested CLI on three live repos (table above)
- [ ] CI green on PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: adds a new CLI query that walks repositories and parses multiple manifest formats (Cargo/npm/pyproject) plus optional symbol-index data, which could mis-detect or incur unexpected IO/glob edge cases on large or unusual repos.
> 
> **Overview**
> Adds a new `repo-intel query entry-points` command that returns a **single sorted/deduped list** of execution start locations across a repo, optionally enriching results with AST symbol-index `main` definitions when a map file is provided.
> 
> Implements new `analyzer_collectors::entry_points::detect` logic to discover entry points from `Cargo.toml` (including workspace member globs + implicit `src/main.rs`), `package.json` (`bin` and `scripts`), and `pyproject.toml` (`[project.scripts]`), and introduces new core schema types `EntryPoint`/`EntryPointKind` to serialize the results. Dependency updates add `toml` and `glob` to support manifest parsing and workspace member expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8424963757b384acd813c5d41ebb49660994ecc8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->