### PR TITLE
docs(README): drop stale AI-detection narrative; surface v0.5 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@
 [![Release](https://github.com/agent-sh/agent-analyzer/actions/workflows/release.yml/badge.svg)](https://github.com/agent-sh/agent-analyzer/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Static analysis binary for the [agent-sh](https://github.com/agent-sh) ecosystem. Extracts temporal, social, and behavioral signals from git history - who changed what, when, how often, and whether AI tools were involved.
+Static analysis binary for the [agent-sh](https://github.com/agent-sh) ecosystem. Extracts temporal, social, and behavioral signals from git history plus AST symbols, project metadata, doc-code sync, and graph-derived community structure.
 
-Produces a single cached JSON artifact that answers questions like "which files change together?", "who owns this module?", and "what percentage of commits are AI-generated?" - without touching git again after the initial scan.
+Produces a single cached JSON artifact that answers questions like "which files change together?", "who owns this module?", "where does this concept live?", and "what does this repo actually do?" - without touching git again after the initial scan.
 
 ## Why this project
 
-- Use this when you need git-based code intelligence (hotspots, coupling, ownership) without shelling out to `git log` on every query
-- Use this when you want to detect and quantify AI-generated commits across a repository
+- Use this when you need git-based code intelligence (hotspots, coupling, ownership, bus factor) without shelling out to `git log` on every query
+- Use this when an agent (or you) needs a fast first-foothold in an unfamiliar repo (`find <concept>`, `entry-points`, `summary`)
 - Use this when you need incremental updates - only process new commits since the last scan
 - Use this when building developer tools that need structured repository history as JSON
+- Use this when you want a Rust crate that stores LLM-augmented signals (per-file descriptors, narrative summary) but never makes the LLM calls itself - the data flows in via `set-descriptors` / `set-summary` from whatever orchestrator you choose
 
 ## Installation
 
@@ -66,20 +67,27 @@ Progress and errors go to stderr, so piping and redirection work as expected.
 
 **Incremental by default**: After the initial scan, `update` only processes commits after `analyzedUpTo`. If a force-push is detected (the recorded SHA is no longer in history), it falls back to a full rebuild automatically.
 
-**AI-aware from the ground up**: Every commit is checked against a multi-signal detection pipeline. The signature registry (`ai_signatures.json`) is data, not code - add new AI tools by editing a JSON file.
+**Offline-only**: The binary never makes network or LLM calls. Per-file descriptors and the 3-depth narrative summary that `find` and `summary` consume are written in by external orchestrators via `set-descriptors` / `set-summary` (the [repo-intel](https://github.com/agent-sh/repo-intel) JS plugin spawns Haiku Task subagents and pipes their JSON output through these subcommands).
+
+**Bot-aware, not AI-attribution**: A `bot_detect` module isolates automation accounts (`dependabot`, `renovate`, `github-actions`) from human contributors. AI authorship attribution was removed in v0.5.0 because it conflated bots with model-assisted authoring and produced misleading ratios.
 
 ## Features
 
 - **Git history extraction** - commit metadata, per-file diff stats, rename tracking, deletion tracking via libgit2 (no subprocess calls)
-- **AI commit detection** - identifies commits from Claude, Cursor, Copilot, Aider, Replit, Windsurf, Devin, and bots like Dependabot and Renovate using trailers, author patterns, and message signatures
-- **Hotspot analysis** - find the most frequently changed files, optionally filtered by time window
+- **Bot detection** - isolates Dependabot, Renovate, GitHub Actions, and other automation from human-authored commits
+- **Bug-fix classification** - recognises `fix:` prefix plus plain-English fix subjects ("Fix race", "Resolves #42", "hotfix"), keyword variants, and issue-closure phrases; suppresses attribution for auto-generated files (`.pb.go`, `.d.ts`, `*/generated/*`) so schema-fix commits don't pollute bugspots
+- **Hotspot analysis** - find the most frequently changed files, recency-weighted
 - **Coupling analysis** - discover files that change together (co-change frequency with configurable thresholds)
-- **Ownership queries** - primary author, contributor breakdown, and bus factor per file or directory
-- **Bus factor** - how many people cover 80% of commits, with optional AI-adjustment
+- **Co-change communities** - Louvain modularity-maximisation on the file-file Jaccard graph; betweenness centrality identifies bridge files
+- **Ownership queries** - primary author, contributor breakdown, and bus factor per file or directory; bots are excluded from bus-factor counts
 - **Convention detection** - conventional commit style, prefix frequency, scope patterns
 - **Release tracking** - tag-based release cadence, unreleased commit count
-- **Health scoring** - composite metric combining activity, bus factor, frequency, and AI ratio
+- **Health scoring** - composite metric combining activity, bus factor, and bug-fix rate
 - **Noise filtering** - automatically excludes lockfiles, minified assets, `dist/`, `build/`, `vendor/` from analysis
+- **AST symbol map** - per-file exports/imports/definitions plus reverse-dependency lookup via tree-sitter (Rust, TS/JS, Python, Go, Java)
+- **Concept search** - `find <concept>` ranks files by deterministic signals (basename/path/symbol/import/doc-header) plus optional LLM-generated descriptor matching for semantic recall
+- **Repo summary** - cached 3-depth narrative description (sentence / paragraph / page), populated by external orchestrator
+- **Entry-point listing** - every place execution can start: binaries (`Cargo.toml [[bin]]`, `package.json bin`, `pyproject scripts`), AST `main` functions, npm `scripts`, with Cargo workspace awareness
 
 ## Usage
 
@@ -117,43 +125,78 @@ agent-analyzer repo-intel query coupling src/engine.rs . --map-file repo-intel.j
 # Who owns a file or directory
 agent-analyzer repo-intel query ownership src/core/ . --map-file repo-intel.json
 
-# Bus factor (people covering 80% of commits)
-agent-analyzer repo-intel query bus-factor . --map-file repo-intel.json --adjust-for-ai
+# Bus factor (people covering 80% of commits, bots excluded)
+agent-analyzer repo-intel query bus-factor . --map-file repo-intel.json
 
 # Newcomer orientation summary
 agent-analyzer repo-intel query onboard . --map-file repo-intel.json
 
 # Outside contributor guidance
 agent-analyzer repo-intel query can-i-help . --map-file repo-intel.json
+
+# Concept-to-file search (uses descriptors when present)
+agent-analyzer repo-intel query find "worker pool" . --map-file repo-intel.json --top 5
+
+# Where execution starts (binaries, AST main fns, npm scripts)
+agent-analyzer repo-intel query entry-points . --map-file repo-intel.json
+
+# Cached 3-depth narrative summary (populated by external orchestrator)
+agent-analyzer repo-intel query summary . --map-file repo-intel.json --depth 1
 ```
+
+### Storing LLM-augmented signals
+
+The binary stays offline-only. To add per-file descriptors or a 3-depth summary, an external orchestrator pipes JSON into the `set-*` subcommands:
+
+```bash
+echo '{"src/auth.rs": "Login route handler — validates credentials against bcrypt hash, issues JWT."}' \
+  | agent-analyzer repo-intel set-descriptors --map-file repo-intel.json --input -
+
+echo '{"depth1": "...", "depth3": "...", "depth10": "...", "inputHash": "sha256:..."}' \
+  | agent-analyzer repo-intel set-summary --map-file repo-intel.json --input -
+```
+
+The [repo-intel](https://github.com/agent-sh/repo-intel) JS plugin's `/repo-intel enrich` action does this automatically by spawning Haiku Task subagents and parsing their JSON output.
 
 ## Architecture
 
-Rust workspace with 6 crates:
+Rust workspace with 7 crates:
 
 ```
-analyzer-core             shared types, git2 wrapper, AI detection, file walking, JSON output
+analyzer-core             shared types, git2 wrapper, bot/bug-fix/generated detection,
+                          file walking, JSON output
     |
     +-- analyzer-git-map      git history extraction, aggregation, queries, incremental
-    +-- analyzer-repo-map     AST-based symbol mapping (Phase 2)
-    +-- analyzer-collectors   project data gathering (Phase 3)
+    +-- analyzer-repo-map     AST-based symbol mapping + concept-to-file search (Phase 2 + Phase 6)
+    +-- analyzer-collectors   project data gathering + entry-point detection (Phase 3)
     +-- analyzer-sync-check   doc-code sync analysis (Phase 4)
+    +-- analyzer-graph        co-change communities + betweenness centrality (Phase 5)
     |
 analyzer-cli              unified binary, clap dispatch
 ```
 
-### AI detection pipeline
+### Bot detection pipeline
 
-Checks are ordered by confidence (highest first):
+The `bot_detect` module identifies automation accounts using two signals:
 
-1. Trailer emails (`Co-Authored-By` containing known AI service emails)
-2. Author emails (known AI tool domains)
-3. Bot authors (exact match: `dependabot[bot]`, `renovate[bot]`)
-4. Author name patterns (regex: `\(aider\)$`, `\[bot\]$`)
-5. Message body patterns (`Generated with Claude Code`, `^aider: `)
-6. Trailer names (`Co-Authored-By` name field: Claude, Cursor, Copilot)
+1. Exact match against a curated list (`dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`, `devin-ai-integration[bot]`, `copilot-swe-agent[bot]`, `Copilot`, `agent-core-bot`)
+2. `[bot]` suffix on the author name
 
-Signatures are loaded from an embedded JSON registry (`ai_signatures.json`). To add a new AI tool, update that file - no code changes needed.
+Bots are excluded from human-contributor counts, bus-factor calculations, and `single_author` risk scoring in diff-risk - so an account that touched a file once via Dependabot doesn't dilute the bus factor signal.
+
+### Bug-fix attribution
+
+The `bug_fix_detect` module classifies a commit subject as a bug fix when **any** of:
+
+1. Conventional Commit prefix is one of `fix`, `bugfix`, `hotfix`, `patch`, `revert`
+2. Subject contains a fix-related whole-word keyword (`fix`/`fixed`/`fixes`/`fixing`, `bug`, `regression`, `race`, `deadlock`, `leak`, `crash`, `oops`, `typo`, ...)
+3. Subject contains an issue-closure phrase (`fixes #123`, `closes #42`, `resolves owner/repo#900`)
+
+Whole-word matching guards against `prefix`/`suffix`/`unfixable` false positives.
+
+### Generated-file suppression
+
+The `generated_detect` module flags `*.pb.go`, `*.d.ts`, `*/generated/*`, `*/codegen/*`, `*.snap` and similar paths as auto-generated. Bug-fix attribution is skipped for these files at aggregation time so a `fix(schema): ...` commit credits the source `.proto` but not the generated bindings - keeps `bugspots` results focused on actually-broken code.
 
 ## Limitations
 
@@ -190,7 +233,7 @@ Consumers:
 3. Ensure `cargo test`, `cargo clippy -- -D warnings`, and `cargo fmt --check` all pass
 4. Open a PR - direct pushes to main are not allowed
 
-To add a new AI tool signature, edit `crates/analyzer-core/src/ai_signatures.json` and add a test case.
+To add a new known bot account, edit the `KNOWN_BOTS` constant in `crates/analyzer-core/src/bot_detect.rs` and add a test case.
 
 ## License
 


### PR DESCRIPTION
README was written when AI attribution was a headline feature; in v0.5.0 the entire AI-detection surface was removed (bots != AI). This PR brings the README in sync with what's actually shipped.

## Removed

- "% of commits are AI-generated" framing
- "AI commit detection" feature bullet
- \`--adjust-for-ai\` flag from the bus-factor example
- "AI detection pipeline" architecture section
- Stale \`ai_signatures.json\` reference

## Added

- New "first foothold" framing in "Why this project" — the v1 use case for find/summary/entry-points
- "Offline-only" core concept (binary never calls LLMs; data flows in via set-* subcommands)
- "Bot-aware, not AI-attribution" core concept
- Feature bullets for: bot detection, broadened bug-fix classification, generated-file suppression, co-change communities + betweenness, concept search, repo summary, entry-points
- Usage examples for: find, entry-points, summary --depth=1
- New "Storing LLM-augmented signals" subsection showing the set-descriptors / set-summary stdin pattern, with pointer to the repo-intel JS plugin's enrich orchestration
- Architecture: 7 crates (was 6 — analyzer-graph was missing); analyzer-core's modules updated (bot/bug-fix/generated detect)
- Replaced "AI detection pipeline" section with three new sections: Bot detection, Bug-fix attribution, Generated-file suppression

## Test plan

- [x] \`cargo test --workspace\` — 213 tests pass (no code changes)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; risk is limited to potential user confusion if the updated CLI/examples or feature descriptions drift from the actual implementation.
> 
> **Overview**
> Refreshes `README.md` to **remove AI-commit attribution framing** (including the `--adjust-for-ai` example and `ai_signatures.json` references) and replace it with **bot-aware, offline-only** positioning.
> 
> Documents newly emphasized capabilities and usage: `find`, `entry-points`, and `summary` queries; `set-descriptors`/`set-summary` stdin-based enrichment by external orchestrators; and updated architecture/feature lists (including `analyzer-graph`, co-change communities, bug-fix classification, and generated-file suppression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927a8364f7e8a7a3c836758c46895b6a5744da1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->