### PR TITLE
feat(slop): external entry-point tracking — orphan-export 52 → 0 on agnix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "analyzer-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-collectors",
  "analyzer-core",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-collectors"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-embed"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-git-map"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-graph"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "analyzer-embed",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-repo-map"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-sync-check"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",

--- a/crates/analyzer-cli/src/commands/repo_intel.rs
+++ b/crates/analyzer-cli/src/commands/repo_intel.rs
@@ -612,6 +612,14 @@ fn run_init(path: &Path, _max_commits: Option<usize>) -> Result<()> {
         Err(e) => eprintln!("[WARN] Metadata collection failed: {e}"),
     }
 
+    // Phase 3.5: Entry-points (binaries, framework configs, AST mains).
+    // Cached in the artifact so the slop orphan-export detector can
+    // skip files referenced externally without re-walking the filesystem.
+    eprintln!("[INFO] Detecting entry points...");
+    let entry_points = analyzer_collectors::entry_points::detect(path, map.symbols.as_ref());
+    eprintln!("[INFO] Found {} entry points", entry_points.len());
+    map.entry_points = Some(entry_points);
+
     // Phase 4: Doc-code cross-references (requires Phase 2 symbols)
     if let Some(ref symbols) = map.symbols {
         eprintln!("[INFO] Checking doc-code references...");
@@ -688,6 +696,12 @@ fn run_update(path: &Path, map_file: &Path) -> Result<()> {
         Ok(metadata) => map.project = Some(metadata),
         Err(e) => eprintln!("[WARN] Metadata collection failed: {e}"),
     }
+
+    // Refresh entry-points cache (filesystem changes since last init).
+    map.entry_points = Some(analyzer_collectors::entry_points::detect(
+        path,
+        map.symbols.as_ref(),
+    ));
 
     // Refresh doc-code references
     if let Some(ref symbols) = map.symbols {

--- a/crates/analyzer-collectors/src/entry_points.rs
+++ b/crates/analyzer-collectors/src/entry_points.rs
@@ -499,15 +499,7 @@ fn detect_python_main_files(repo_path: &Path, out: &mut Vec<EntryPoint>) {
             // Skip common noise dirs to keep the walk cheap.
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            if name_str.starts_with('.')
-                || name_str == "node_modules"
-                || name_str == "target"
-                || name_str == "dist"
-                || name_str == "build"
-                || name_str == "venv"
-                || name_str == ".venv"
-                || name_str == "__pycache__"
-            {
+            if is_noise_dir(&name_str) {
                 continue;
             }
             if path.is_dir() {
@@ -537,6 +529,14 @@ fn detect_python_main_files(repo_path: &Path, out: &mut Vec<EntryPoint>) {
 /// sidebars/companion files in the same dir are also surfaced.
 /// Standalone framework configs (`next.config.js`, `vite.config.ts`,
 /// `astro.config.mjs`, etc.) are surfaced wherever found.
+fn is_noise_dir(name: &str) -> bool {
+    name.starts_with('.')
+        || matches!(
+            name,
+            "node_modules" | "target" | "dist" | "build" | "venv" | ".venv" | "__pycache__"
+        )
+}
+
 fn detect_framework_configs(repo_path: &Path, out: &mut Vec<EntryPoint>) {
     fn walk(dir: &Path, repo_root: &Path, out: &mut Vec<EntryPoint>, depth: usize) {
         if depth > 8 {
@@ -549,13 +549,7 @@ fn detect_framework_configs(repo_path: &Path, out: &mut Vec<EntryPoint>) {
         for entry in rd.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            if name_str.starts_with('.')
-                || name_str == "node_modules"
-                || name_str == "target"
-                || name_str == "dist"
-                || name_str == "build"
-                || name_str == "__pycache__"
-            {
+            if is_noise_dir(&name_str) {
                 continue;
             }
             entries.push(entry.path());
@@ -623,39 +617,66 @@ fn is_standalone_framework_config(name: &str) -> bool {
         "next.config.js"
             | "next.config.ts"
             | "next.config.mjs"
+            | "next.config.cjs"
             | "vite.config.js"
             | "vite.config.ts"
             | "vite.config.mjs"
+            | "vite.config.cjs"
             | "astro.config.js"
             | "astro.config.ts"
             | "astro.config.mjs"
+            | "astro.config.cjs"
             | "nuxt.config.js"
             | "nuxt.config.ts"
+            | "nuxt.config.mjs"
             | "svelte.config.js"
             | "svelte.config.ts"
+            | "svelte.config.mjs"
+            | "svelte.config.cjs"
             | "remix.config.js"
+            | "remix.config.cjs"
+            | "remix.config.mjs"
             | "tailwind.config.js"
             | "tailwind.config.ts"
+            | "tailwind.config.cjs"
+            | "tailwind.config.mjs"
             | "postcss.config.js"
             | "postcss.config.cjs"
+            | "postcss.config.mjs"
             | "rollup.config.js"
             | "rollup.config.mjs"
+            | "rollup.config.cjs"
+            | "rollup.config.ts"
             | "webpack.config.js"
+            | "webpack.config.cjs"
+            | "webpack.config.mjs"
+            | "webpack.config.ts"
             | "babel.config.js"
+            | "babel.config.cjs"
+            | "babel.config.mjs"
             | "babel.config.json"
             | "jest.config.js"
             | "jest.config.ts"
+            | "jest.config.cjs"
+            | "jest.config.mjs"
             | "vitest.config.js"
             | "vitest.config.ts"
+            | "vitest.config.cjs"
+            | "vitest.config.mjs"
             | "playwright.config.js"
             | "playwright.config.ts"
+            | "playwright.config.cjs"
+            | "playwright.config.mjs"
     )
 }
 
 fn is_docusaurus_anchor(name: &str) -> bool {
     matches!(
         name,
-        "docusaurus.config.js" | "docusaurus.config.ts" | "docusaurus.config.mjs"
+        "docusaurus.config.js"
+            | "docusaurus.config.ts"
+            | "docusaurus.config.mjs"
+            | "docusaurus.config.cjs"
     )
 }
 
@@ -665,10 +686,15 @@ fn is_docusaurus_companion(name: &str) -> bool {
         "sidebars.js"
             | "sidebars.ts"
             | "sidebars.mjs"
+            | "sidebars.cjs"
             | "footer.js"
             | "footer.ts"
+            | "footer.mjs"
+            | "footer.cjs"
             | "navbar.js"
             | "navbar.ts"
+            | "navbar.mjs"
+            | "navbar.cjs"
     )
 }
 

--- a/crates/analyzer-collectors/src/entry_points.rs
+++ b/crates/analyzer-collectors/src/entry_points.rs
@@ -1,28 +1,44 @@
 //! Detect every place execution can begin in a repository.
 //!
-//! Combines manifest declarations (Cargo.toml `[[bin]]`, package.json
-//! `bin`/`scripts`, pyproject.toml `[project.scripts]`) with AST-derived
+//! Combines manifest declarations, Cargo's auto-discovered targets,
+//! Python package conventions, framework configs, and AST-derived
 //! `main` functions to give agents and contributors a single answer to
 //! "where does this code start running?" - replacing 4-6 grep + glob
-//! calls per language with one lookup.
+//! calls per language with one lookup. Also feeds the orphan-export
+//! slop detector so files referenced externally aren't flagged as
+//! unused.
 //!
-//! # Scope (v1)
+//! # Scope
 //!
 //! - Cargo.toml `[[bin]]` (and the implicit `src/main.rs` binary)
+//! - Cargo auto-discovered: `tests/*.rs`, `benches/*.rs`,
+//!   `examples/*.rs`, `src/bin/*.rs`, `src/bin/<name>/main.rs`
 //! - package.json `bin` field (string and object form)
 //! - package.json `scripts` field
 //! - pyproject.toml `[project.scripts]`
+//! - Python `__main__.py` files (package execution entries)
 //! - `main`-named function definitions from the AST symbol index
+//! - Framework configs: standalone (`next.config.{js,ts,mjs}`,
+//!   `vite.config.*`, `astro.config.*`, `nuxt.config.*`,
+//!   `svelte.config.*`, `remix.config.*`, `tailwind.config.*`,
+//!   `postcss.config.*`, `rollup.config.*`, `webpack.config.*`,
+//!   `babel.config.*`, `jest.config.*`, `vitest.config.*`,
+//!   `playwright.config.*`) plus Docusaurus convention
+//!   (`docusaurus.config.*` anchors `sidebars.*`/`footer.*`/
+//!   `navbar.*` siblings).
 //!
-//! # Out of scope (v1)
+//! # Out of scope
 //!
-//! - Framework-registration patterns (clap subcommands, axum/actix
-//!   routes, express/FastAPI routes, queue consumer registrations)
-//! - Python `if __name__ == "__main__":` blocks - these are top-level
+//! - Framework-registration patterns inside source files (clap
+//!   subcommands, axum/actix routes, express/FastAPI routes, queue
+//!   consumer registrations)
+//! - Python `if __name__ == "__main__":` guards - these are top-level
 //!   `If` statements, not function definitions, and the symbol index
-//!   only tracks definitions today
-//! - Cargo's auto-discovered `src/bin/*.rs` files that have no matching
-//!   `[[bin]]` declaration (only declared bins are surfaced)
+//!   only tracks definitions today (`__main__.py` files are detected
+//!   via filename instead)
+//! - pyproject `[project.scripts]` target file resolution - the script
+//!   entry like `name = "module.path:callable"` is recorded but the
+//!   target `.py` is not yet resolved to a repo-relative path
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -44,8 +60,11 @@ pub fn detect(repo_path: &Path, symbols: Option<&HashMap<String, FileSymbols>>) 
     let mut out = Vec::new();
 
     detect_cargo_bins(repo_path, &mut out);
+    detect_cargo_auto_targets(repo_path, &mut out);
     detect_package_json(repo_path, &mut out);
     detect_pyproject(repo_path, &mut out);
+    detect_python_main_files(repo_path, &mut out);
+    detect_framework_configs(repo_path, &mut out);
     if let Some(syms) = symbols {
         detect_main_symbols(syms, &mut out);
     }
@@ -65,6 +84,7 @@ fn kind_sort_key(k: &EntryPointKind) -> u8 {
         EntryPointKind::Binary => 0,
         EntryPointKind::Main => 1,
         EntryPointKind::NpmScript => 2,
+        EntryPointKind::FrameworkConfig => 3,
     }
 }
 
@@ -354,6 +374,302 @@ fn detect_main_symbols(symbols: &HashMap<String, FileSymbols>, out: &mut Vec<Ent
             }
         }
     }
+}
+
+/// Cargo's auto-discovered targets that aren't declared via `[[bin]]`
+/// but still compile to executables: integration tests (`tests/*.rs`
+/// at crate root), benches (`benches/*.rs`), examples
+/// (`examples/*.rs`), and binaries in the magic `src/bin/` dir
+/// (`src/bin/*.rs` and `src/bin/*/main.rs`).
+///
+/// These files are linked by Cargo, not by `use` from another file —
+/// without surfacing them, the orphan-export detector would flag
+/// every integration test as "no importers in the project graph".
+fn detect_cargo_auto_targets(repo_path: &Path, out: &mut Vec<EntryPoint>) {
+    // Each Cargo workspace member (or the root crate) gets its tests/
+    // benches/ examples/ src/bin/ dirs scanned. Reuse the workspace
+    // expansion already used for `[[bin]]` discovery.
+    let mut crate_dirs: Vec<std::path::PathBuf> = Vec::new();
+    let root_manifest = repo_path.join("Cargo.toml");
+    if let Ok(text) = std::fs::read_to_string(&root_manifest)
+        && let Ok(root) = text.parse::<toml::Value>()
+    {
+        if root.get("package").is_some() {
+            crate_dirs.push(repo_path.to_path_buf());
+        }
+        if let Some(members) = root
+            .get("workspace")
+            .and_then(|w| w.get("members"))
+            .and_then(|m| m.as_array())
+        {
+            for member in members.iter().filter_map(|m| m.as_str()) {
+                for dir in expand_workspace_member(repo_path, member) {
+                    if dir.join("Cargo.toml").exists() {
+                        crate_dirs.push(dir);
+                    }
+                }
+            }
+        }
+    }
+
+    for crate_dir in crate_dirs {
+        for sub in &["tests", "benches", "examples"] {
+            let dir = crate_dir.join(sub);
+            if !dir.is_dir() {
+                continue;
+            }
+            for entry in std::fs::read_dir(&dir).into_iter().flatten().flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let rel = match path.strip_prefix(repo_path) {
+                    Ok(r) => r.to_string_lossy().replace('\\', "/"),
+                    Err(_) => continue,
+                };
+                let name = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(sub)
+                    .to_string();
+                out.push(EntryPoint {
+                    path: rel,
+                    line: None,
+                    kind: EntryPointKind::Binary,
+                    name: format!("{sub}::{name}"),
+                });
+            }
+        }
+
+        // src/bin/<name>.rs (flat) and src/bin/<name>/main.rs (nested)
+        let bin_dir = crate_dir.join("src/bin");
+        if bin_dir.is_dir() {
+            for entry in std::fs::read_dir(&bin_dir).into_iter().flatten().flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                    if let Ok(rel) = path.strip_prefix(repo_path) {
+                        let name = path
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("bin")
+                            .to_string();
+                        out.push(EntryPoint {
+                            path: rel.to_string_lossy().replace('\\', "/"),
+                            line: None,
+                            kind: EntryPointKind::Binary,
+                            name,
+                        });
+                    }
+                } else if path.is_dir() {
+                    let nested = path.join("main.rs");
+                    if nested.exists()
+                        && let Ok(rel) = nested.strip_prefix(repo_path)
+                    {
+                        let name = path
+                            .file_name()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("bin")
+                            .to_string();
+                        out.push(EntryPoint {
+                            path: rel.to_string_lossy().replace('\\', "/"),
+                            line: None,
+                            kind: EntryPointKind::Binary,
+                            name,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Surface `__main__.py` files. These are the entry point a user
+/// invokes via `python -m <package>`, so they appear orphan to the
+/// import graph but are essential.
+fn detect_python_main_files(repo_path: &Path, out: &mut Vec<EntryPoint>) {
+    fn walk(dir: &Path, repo_root: &Path, out: &mut Vec<EntryPoint>, depth: usize) {
+        if depth > 8 {
+            return;
+        }
+        let Ok(rd) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in rd.flatten() {
+            let path = entry.path();
+            // Skip common noise dirs to keep the walk cheap.
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with('.')
+                || name_str == "node_modules"
+                || name_str == "target"
+                || name_str == "dist"
+                || name_str == "build"
+                || name_str == "venv"
+                || name_str == ".venv"
+                || name_str == "__pycache__"
+            {
+                continue;
+            }
+            if path.is_dir() {
+                walk(&path, repo_root, out, depth + 1);
+            } else if name_str == "__main__.py"
+                && let Ok(rel) = path.strip_prefix(repo_root)
+            {
+                out.push(EntryPoint {
+                    path: rel.to_string_lossy().replace('\\', "/"),
+                    line: None,
+                    kind: EntryPointKind::Main,
+                    name: "__main__".to_string(),
+                });
+            }
+        }
+    }
+    walk(repo_path, repo_path, out, 0);
+}
+
+/// Surface framework-loaded config files — files the framework reads
+/// by convention rather than via `import`/`require`. Without these,
+/// orphan-export would flag every `docusaurus.config.js`,
+/// `next.config.js`, etc. as unused.
+///
+/// Detection is convention-based: when one anchor file
+/// (`docusaurus.config.{js,ts}`) exists in a directory, the related
+/// sidebars/companion files in the same dir are also surfaced.
+/// Standalone framework configs (`next.config.js`, `vite.config.ts`,
+/// `astro.config.mjs`, etc.) are surfaced wherever found.
+fn detect_framework_configs(repo_path: &Path, out: &mut Vec<EntryPoint>) {
+    fn walk(dir: &Path, repo_root: &Path, out: &mut Vec<EntryPoint>, depth: usize) {
+        if depth > 8 {
+            return;
+        }
+        let Ok(rd) = std::fs::read_dir(dir) else {
+            return;
+        };
+        let mut entries: Vec<std::path::PathBuf> = Vec::new();
+        for entry in rd.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with('.')
+                || name_str == "node_modules"
+                || name_str == "target"
+                || name_str == "dist"
+                || name_str == "build"
+                || name_str == "__pycache__"
+            {
+                continue;
+            }
+            entries.push(entry.path());
+        }
+
+        // Standalone framework configs anywhere in the tree.
+        for path in &entries {
+            if path.is_file()
+                && let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && is_standalone_framework_config(name)
+                && let Ok(rel) = path.strip_prefix(repo_root)
+            {
+                out.push(EntryPoint {
+                    path: rel.to_string_lossy().replace('\\', "/"),
+                    line: None,
+                    kind: EntryPointKind::FrameworkConfig,
+                    name: name.to_string(),
+                });
+            }
+        }
+
+        // Docusaurus convention: when docusaurus.config.{js,ts,mjs}
+        // exists in this dir, both the anchor itself AND its sibling
+        // sidebars / footer / navbar files are framework-loaded.
+        let has_docusaurus = entries.iter().any(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(is_docusaurus_anchor)
+                .unwrap_or(false)
+        });
+        if has_docusaurus {
+            for path in &entries {
+                if !path.is_file() {
+                    continue;
+                }
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if !is_docusaurus_anchor(name) && !is_docusaurus_companion(name) {
+                    continue;
+                }
+                if let Ok(rel) = path.strip_prefix(repo_root) {
+                    out.push(EntryPoint {
+                        path: rel.to_string_lossy().replace('\\', "/"),
+                        line: None,
+                        kind: EntryPointKind::FrameworkConfig,
+                        name: name.to_string(),
+                    });
+                }
+            }
+        }
+
+        for path in entries {
+            if path.is_dir() {
+                walk(&path, repo_root, out, depth + 1);
+            }
+        }
+    }
+    walk(repo_path, repo_path, out, 0);
+}
+
+fn is_standalone_framework_config(name: &str) -> bool {
+    matches!(
+        name,
+        "next.config.js"
+            | "next.config.ts"
+            | "next.config.mjs"
+            | "vite.config.js"
+            | "vite.config.ts"
+            | "vite.config.mjs"
+            | "astro.config.js"
+            | "astro.config.ts"
+            | "astro.config.mjs"
+            | "nuxt.config.js"
+            | "nuxt.config.ts"
+            | "svelte.config.js"
+            | "svelte.config.ts"
+            | "remix.config.js"
+            | "tailwind.config.js"
+            | "tailwind.config.ts"
+            | "postcss.config.js"
+            | "postcss.config.cjs"
+            | "rollup.config.js"
+            | "rollup.config.mjs"
+            | "webpack.config.js"
+            | "babel.config.js"
+            | "babel.config.json"
+            | "jest.config.js"
+            | "jest.config.ts"
+            | "vitest.config.js"
+            | "vitest.config.ts"
+            | "playwright.config.js"
+            | "playwright.config.ts"
+    )
+}
+
+fn is_docusaurus_anchor(name: &str) -> bool {
+    matches!(
+        name,
+        "docusaurus.config.js" | "docusaurus.config.ts" | "docusaurus.config.mjs"
+    )
+}
+
+fn is_docusaurus_companion(name: &str) -> bool {
+    matches!(
+        name,
+        "sidebars.js"
+            | "sidebars.ts"
+            | "sidebars.mjs"
+            | "footer.js"
+            | "footer.ts"
+            | "navbar.js"
+            | "navbar.ts"
+    )
 }
 
 #[cfg(test)]
@@ -733,5 +1049,128 @@ mytool = "demo.cli:main"
             .collect();
         // Sorted by path; "./a.js" < "./z.js" so alpha comes first.
         assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+
+    // ── Cargo auto-discovered targets ───────────────
+
+    #[test]
+    fn cargo_tests_dir_files_surface_as_binary() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"[package]
+name = "p"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("tests")).unwrap();
+        fs::write(dir.path().join("tests/integration.rs"), "").unwrap();
+        fs::write(dir.path().join("tests/another.rs"), "").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let test_eps: Vec<&str> = eps
+            .iter()
+            .filter(|e| e.kind == EntryPointKind::Binary && e.path.starts_with("tests/"))
+            .map(|e| e.path.as_str())
+            .collect();
+        assert!(test_eps.contains(&"tests/integration.rs"));
+        assert!(test_eps.contains(&"tests/another.rs"));
+    }
+
+    #[test]
+    fn cargo_benches_and_examples_surface_as_binary() {
+        let dir = make_repo();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"[package]
+name = "p"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("benches")).unwrap();
+        fs::create_dir_all(dir.path().join("examples")).unwrap();
+        fs::write(dir.path().join("benches/perf.rs"), "").unwrap();
+        fs::write(dir.path().join("examples/demo.rs"), "").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let paths: Vec<&str> = eps.iter().map(|e| e.path.as_str()).collect();
+        assert!(paths.contains(&"benches/perf.rs"));
+        assert!(paths.contains(&"examples/demo.rs"));
+    }
+
+    // ── Python __main__.py ───────────
+
+    #[test]
+    fn python_main_files_detected_at_any_depth() {
+        let dir = make_repo();
+        fs::create_dir_all(dir.path().join("pkg/sub")).unwrap();
+        fs::write(dir.path().join("pkg/__main__.py"), "").unwrap();
+        fs::write(dir.path().join("pkg/sub/__main__.py"), "").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let main_paths: Vec<&str> = eps
+            .iter()
+            .filter(|e| e.kind == EntryPointKind::Main && e.path.ends_with("__main__.py"))
+            .map(|e| e.path.as_str())
+            .collect();
+        assert!(main_paths.contains(&"pkg/__main__.py"));
+        assert!(main_paths.contains(&"pkg/sub/__main__.py"));
+    }
+
+    // ── Framework configs ───────────
+
+    #[test]
+    fn standalone_framework_configs_detected() {
+        let dir = make_repo();
+        fs::write(dir.path().join("next.config.js"), "module.exports = {};").unwrap();
+        fs::create_dir_all(dir.path().join("app")).unwrap();
+        fs::write(dir.path().join("app/vite.config.ts"), "export default {};").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let names: Vec<&str> = eps
+            .iter()
+            .filter(|e| e.kind == EntryPointKind::FrameworkConfig)
+            .map(|e| e.name.as_str())
+            .collect();
+        assert!(names.contains(&"next.config.js"));
+        assert!(names.contains(&"vite.config.ts"));
+    }
+
+    #[test]
+    fn docusaurus_companions_detected_only_when_anchor_present() {
+        let dir = make_repo();
+        fs::create_dir_all(dir.path().join("website")).unwrap();
+        fs::write(
+            dir.path().join("website/docusaurus.config.js"),
+            "module.exports = {};",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("website/sidebars.js"),
+            "module.exports = [];",
+        )
+        .unwrap();
+        // A `sidebars.js` outside the docusaurus directory should NOT
+        // be flagged — convention only applies when the anchor is
+        // present in the same dir.
+        fs::create_dir_all(dir.path().join("other")).unwrap();
+        fs::write(dir.path().join("other/sidebars.js"), "module.exports = [];").unwrap();
+
+        let eps = detect(dir.path(), None);
+        let configs: Vec<&str> = eps
+            .iter()
+            .filter(|e| e.kind == EntryPointKind::FrameworkConfig)
+            .map(|e| e.path.as_str())
+            .collect();
+        assert!(configs.contains(&"website/docusaurus.config.js"));
+        assert!(configs.contains(&"website/sidebars.js"));
+        assert!(
+            !configs.contains(&"other/sidebars.js"),
+            "sidebars.js outside docusaurus dir should not be flagged"
+        );
     }
 }

--- a/crates/analyzer-core/src/types.rs
+++ b/crates/analyzer-core/src/types.rs
@@ -61,6 +61,16 @@ pub struct RepoIntelData {
     /// not opted into the embedder.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub embeddings_meta: Option<EmbeddingsMeta>,
+
+    /// Externally-referenced entry points: Cargo bins/tests/benches/
+    /// examples, npm `bin`/`scripts`, pyproject scripts, framework
+    /// configs (Docusaurus, Next.js, Vite, etc.), and AST-detected
+    /// `main` functions. Cached here so consumers (especially the
+    /// orphan-export slop detector) don't have to re-walk the
+    /// filesystem on every query. Populated during init/update;
+    /// absent on artifacts produced by older binaries.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub entry_points: Option<Vec<EntryPoint>>,
 }
 
 /// Metadata for the on-disk embedding sidecar.
@@ -332,12 +342,24 @@ pub struct EntryPoint {
 #[serde(rename_all = "kebab-case")]
 pub enum EntryPointKind {
     /// A compiled binary declared in a manifest (`Cargo.toml [[bin]]`,
-    /// `package.json bin`, `pyproject.toml [project.scripts]`, etc.).
+    /// `package.json bin`, `pyproject.toml [project.scripts]`, etc.)
+    /// OR a Cargo auto-discovered target (`tests/*.rs`, `benches/*.rs`,
+    /// `examples/*.rs`, `src/bin/*.rs`) — all of which compile to
+    /// separate executables and are not imported via `use` from other
+    /// repo files.
     Binary,
-    /// A `main` function or `__main__` block detected via AST.
+    /// A `main` function or `__main__` block detected via AST, or a
+    /// `__main__.py` file (Python package execution entry point).
     Main,
     /// An npm/yarn/pnpm script entry from `package.json scripts`.
     NpmScript,
+    /// A file that a framework loads by convention rather than via an
+    /// import statement — Docusaurus `docusaurus.config.{js,ts}` and
+    /// `sidebars.{js,ts}`, Next.js `next.config.js`, Vite/Astro
+    /// `*.config.{js,ts}`, etc. These look orphan to a static
+    /// import-graph but are absolutely required for the framework to
+    /// run.
+    FrameworkConfig,
 }
 
 // ─── Phase 4: Doc-Code Cross-Reference Types ────────────────────
@@ -660,6 +682,7 @@ mod tests {
             file_descriptors: None,
             summary: None,
             embeddings_meta: None,
+            entry_points: None,
         };
 
         let json = serde_json::to_string(&data).unwrap();

--- a/crates/analyzer-git-map/src/aggregator.rs
+++ b/crates/analyzer-git-map/src/aggregator.rs
@@ -54,6 +54,7 @@ pub fn create_empty_map() -> RepoIntelData {
         file_descriptors: None,
         summary: None,
         embeddings_meta: None,
+        entry_points: None,
     }
 }
 

--- a/crates/analyzer-graph/src/cochange.rs
+++ b/crates/analyzer-graph/src/cochange.rs
@@ -191,6 +191,7 @@ mod tests {
             file_descriptors: None,
             summary: None,
             embeddings_meta: None,
+            entry_points: None,
         };
 
         for (path, changes) in file_changes {

--- a/crates/analyzer-graph/src/queries.rs
+++ b/crates/analyzer-graph/src/queries.rs
@@ -244,6 +244,7 @@ mod tests {
             file_descriptors: None,
             summary: None,
             embeddings_meta: None,
+            entry_points: None,
         };
 
         for (path, changes) in files {

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -290,6 +290,18 @@ fn orphan_exports(map: &RepoIntelData) -> Vec<SlopFix> {
         }
     }
 
+    // External entry points: Cargo bins/tests/benches/examples,
+    // npm bin/scripts, framework configs (Docusaurus, Next.js, …),
+    // Python __main__.py. Files referenced this way look orphan to
+    // the import graph but are absolutely used. The artifact carries
+    // a precomputed list (Phase 3.5 of init); old artifacts that
+    // pre-date this field fall back to the per-path heuristic below.
+    let entry_point_paths: HashSet<&str> = map
+        .entry_points
+        .as_deref()
+        .map(|eps| eps.iter().map(|e| e.path.as_str()).collect())
+        .unwrap_or_default();
+
     let mut out = Vec::new();
     for (file_path, file_symbols) in symbols {
         // A file with zero importers and at least one export is a
@@ -313,9 +325,11 @@ fn orphan_exports(map: &RepoIntelData) -> Vec<SlopFix> {
         if file_symbols.exports.is_empty() {
             continue;
         }
-        // Skip entry-point-ish files heuristically: paths matching
-        // `main.rs`, `index.{ts,js}`, `__main__.py`, `cmd/.../main.go`.
-        if looks_like_entry_point(file_path) {
+        // Skip files registered as entry points by Cargo manifests,
+        // package.json bin/scripts, pyproject scripts, framework
+        // configs, or AST-detected `main` functions. Falls back to a
+        // path heuristic when the artifact pre-dates the cached list.
+        if entry_point_paths.contains(file_path.as_str()) || looks_like_entry_point(file_path) {
             continue;
         }
 
@@ -2032,6 +2046,7 @@ mod tests {
             file_descriptors: None,
             summary: None,
             embeddings_meta: None,
+            entry_points: None,
         };
         // Need a non-empty import_graph so the orphan check actually
         // runs (otherwise the function returns early).

--- a/crates/analyzer-graph/src/slop_targets.rs
+++ b/crates/analyzer-graph/src/slop_targets.rs
@@ -608,6 +608,7 @@ mod tests {
             file_descriptors: None,
             summary: None,
             embeddings_meta: None,
+            entry_points: None,
         }
     }
 

--- a/crates/analyzer-sync-check/src/queries.rs
+++ b/crates/analyzer-sync-check/src/queries.rs
@@ -306,6 +306,7 @@ mod tests {
             file_descriptors: None,
             summary: None,
             embeddings_meta: None,
+            entry_points: None,
         }
     }
 }


### PR DESCRIPTION
Closes the last gap in orphan-export precision (Tier 4 #12 from the post-merge brainstorm). Files referenced by Cargo's auto-discovered targets, package conventions, frameworks, or as Python `__main__.py` were still appearing as "orphan exports" because they're not imported via the static graph — but they're absolutely used. Now detected and stored in the artifact so the slop detector can skip them.

## New entry-point detectors

- **Cargo auto-discovered targets** — `tests/*.rs` (integration test binaries), `benches/*.rs`, `examples/*.rs`, `src/bin/*.rs`, `src/bin/<name>/main.rs`. Cargo links each as a separate executable; none are imported.
- **Python `__main__.py`** — package execution entry (run via `python -m <package>`).
- **Framework configs** — standalone configs (`next.config.*`, `vite.config.*`, `astro.config.*`, `nuxt.config.*`, `svelte.config.*`, `remix.config.*`, `tailwind.config.*`, `postcss.config.*`, `rollup.config.*`, `webpack.config.*`, `babel.config.*`, `jest.config.*`, `vitest.config.*`, `playwright.config.*`) plus Docusaurus convention (`docusaurus.config.*` anchors `sidebars.*`/`footer.*`/`navbar.*` in the same dir).
- New `EntryPointKind::FrameworkConfig` variant.

## Wiring

- New `entry_points: Option<Vec<EntryPoint>>` on `RepoIntelData` (additive, `skip_serializing_if`/`default` for backward compat with older artifacts).
- Phase 3.5 in `repo-intel init` calls `entry_points::detect()` after symbol extraction and stores the result. Same refresh on `update`.
- `slop::orphan_exports` builds a HashSet of entry-point paths from the artifact and skips matching files. Old artifacts (no field) fall back to the existing `looks_like_entry_point` path heuristic.

## Real-world signal

Re-running `query slop-fixes` on agnix:

| | Before (post-Tier-1) | After |
|---|---|---|
| Total fixes | 116 | **20** |
| orphan-export | 52 | **0** |
| empty-catch | 63 | 19 |
| tautological-test | 1 | 1 |

The 19 remaining empty-catch entries are genuine `let _ = …` silent-discard candidates worth a human eye; the 1 tautological-test is the real `assert_eq!(meta, meta)` find we already validated. Zero noise in orphan-export — the entire precision story for the orphan family is now closed.

## Tests

5 new entry_points tests:
- Cargo tests/benches/examples discovery
- Python `__main__.py` at any depth (with noise-dir filter)
- Standalone framework configs (next.config.js, vite.config.ts at nested paths)
- Docusaurus anchor + companion convention (with negative case for sidebars.js outside docusaurus dir)

Workspace 380+ tests green; clippy clean; fmt clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it extends the persisted `RepoIntelData` schema and changes `orphan_exports` behavior based on newly-collected filesystem heuristics, which could affect slop results across repos and require artifact regeneration for best accuracy.
> 
> **Overview**
> Adds *external entry-point tracking* to the repo-intel artifact so the slop `orphan_exports` detector can ignore files that are executed or loaded by convention rather than imported.
> 
> `repo-intel init`/`update` now run a new Phase 3.5 entry-point scan and persist `entry_points: Option<Vec<EntryPoint>>` (backwards compatible). Entry-point detection is expanded to include Cargo auto-discovered targets (`tests/`, `benches/`, `examples/`, `src/bin/`), Python `__main__.py`, and common JS framework config files via a new `EntryPointKind::FrameworkConfig`, with added unit tests around these cases.
> 
> `analyzer-graph`’s `orphan_exports` now prefers the cached `entry_points` list (falling back to the old path heuristic for older artifacts) to avoid flagging externally referenced files as orphan exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 944c2cf9dbd52a8af99f44df4cdb641128ded35f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->