### PR TITLE
feat(slop): word-boundary cliché matching + agnix-ignore directives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "analyzer-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-collectors",
  "analyzer-core",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-collectors"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-embed"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-git-map"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-graph"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "analyzer-embed",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-repo-map"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-sync-check"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "analyzer-core",
  "anyhow",

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -130,10 +130,12 @@ fn apply_suppressions(repo_root: &Path, fixes: Vec<SlopFix>) -> Vec<SlopFix> {
                 return true;
             }
             let path = path.unwrap();
-            let suppressions = cache
-                .entry(path.to_string())
-                .or_insert_with(|| FileSuppressions::load(repo_root, path));
-            let Some(supp) = suppressions else {
+            // Avoid the per-call String allocation that `entry()` would
+            // force on every cache hit; only allocate when inserting.
+            if !cache.contains_key(path) {
+                cache.insert(path.to_string(), FileSuppressions::load(repo_root, path));
+            }
+            let Some(supp) = cache.get(path).and_then(|o| o.as_ref()) else {
                 return true;
             };
             !supp.suppresses(fix)
@@ -176,23 +178,21 @@ impl FileSuppressions {
         for (idx, line) in content.lines().enumerate() {
             let line_no = (idx as u32) + 1;
             let in_header = line_no <= 5;
-            let trimmed = line.trim_start();
 
-            // Strip a single leading comment marker (//, #, --) so we
-            // can detect the directive uniformly across languages.
-            let after_marker = trimmed
-                .strip_prefix("// ")
-                .or_else(|| trimmed.strip_prefix("//"))
-                .or_else(|| trimmed.strip_prefix("# "))
-                .or_else(|| trimmed.strip_prefix("#"))
-                .or_else(|| trimmed.strip_prefix("-- "))
-                .or_else(|| trimmed.strip_prefix("--"));
-            let Some(directive) = after_marker else {
+            // Find any agentsys-ignore directive on this line, whether
+            // the line is a comment-only line OR a code line with a
+            // trailing comment (`catch {} // agentsys-ignore: …`).
+            // We scan for the directive substring directly, then walk
+            // back to confirm it's preceded by a recognized comment
+            // marker (`//`, `#`, `--`). This avoids the trim_start +
+            // strip_prefix path which only handled comment-only lines.
+            let Some(directive) = find_agentsys_directive(line) else {
                 continue;
             };
-            let directive = directive.trim();
 
-            if directive == "agentsys-ignore-all" || directive.starts_with("agentsys-ignore-all ") {
+            if directive == "agentsys-ignore-all"
+                || directive.starts_with("agentsys-ignore-all ")
+            {
                 if in_header {
                     s.header_all = true;
                 }
@@ -200,9 +200,14 @@ impl FileSuppressions {
                 continue;
             }
             if let Some(rest) = directive.strip_prefix("agentsys-ignore:") {
+                // Strip trailing comments / whitespace per category so
+                // `// agentsys-ignore: empty-catch trailing notes` works.
                 let cats = rest
+                    .split('#')
+                    .next()
+                    .unwrap_or("")
                     .split(',')
-                    .map(|c| c.trim().to_string())
+                    .filter_map(|c| c.split_whitespace().next().map(str::to_string))
                     .filter(|c| !c.is_empty());
                 let entry = s.line_categories.entry(line_no).or_default();
                 for cat in cats {
@@ -217,13 +222,10 @@ impl FileSuppressions {
     }
 
     fn suppresses(&self, fix: &SlopFix) -> bool {
-        let cat_str = serde_json::to_value(fix.category)
-            .ok()
-            .and_then(|v| v.as_str().map(|s| s.to_string()))
-            .unwrap_or_default();
+        let cat_str = category_kebab(fix.category);
         match &fix.action {
             SlopAction::DeleteFile { .. } => {
-                self.header_all || self.header_categories.contains(&cat_str)
+                self.header_all || self.header_categories.contains(cat_str)
             }
             SlopAction::DeleteLines { lines, .. } | SlopAction::ReplaceLines { lines, .. } => {
                 let target_line = lines[0];
@@ -244,7 +246,7 @@ impl FileSuppressions {
                     if self
                         .line_categories
                         .get(&candidate)
-                        .map(|set| set.contains(&cat_str))
+                        .map(|set| set.contains(cat_str))
                         .unwrap_or(false)
                     {
                         return true;
@@ -253,6 +255,38 @@ impl FileSuppressions {
                 false
             }
         }
+    }
+}
+
+/// Locate an `agentsys-ignore...` directive on a single source line.
+/// Handles both comment-only lines (`// agentsys-ignore: …`) and
+/// inline trailing comments (`catch {} // agentsys-ignore: …`) by
+/// scanning for the directive substring and confirming a recognized
+/// comment marker (`//`, `#`, `--`) appears before it.
+fn find_agentsys_directive(line: &str) -> Option<&str> {
+    let pos = line.find("agentsys-ignore")?;
+    // Walk back through whitespace to the comment marker.
+    let prefix = line[..pos].trim_end();
+    let valid_marker = prefix.ends_with("//")
+        || prefix.ends_with('#')
+        || prefix.ends_with("--");
+    if !valid_marker {
+        return None;
+    }
+    Some(line[pos..].trim_end())
+}
+
+/// Map a [`SlopCategory`] to its kebab-case string. Avoids the
+/// per-call `serde_json::to_value` allocation flagged by reviewers —
+/// this is hit on every fix during suppression filtering.
+fn category_kebab(c: SlopCategory) -> &'static str {
+    match c {
+        SlopCategory::TrackedArtifact => "tracked-artifact",
+        SlopCategory::StaleCiConfig => "stale-ci-config",
+        SlopCategory::DuplicateTooling => "duplicate-tooling",
+        SlopCategory::OrphanExport => "orphan-export",
+        SlopCategory::EmptyCatch => "empty-catch",
+        SlopCategory::TautologicalTest => "tautological-test",
     }
 }
 

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -190,9 +190,7 @@ impl FileSuppressions {
                 continue;
             };
 
-            if directive == "agentsys-ignore-all"
-                || directive.starts_with("agentsys-ignore-all ")
-            {
+            if directive == "agentsys-ignore-all" || directive.starts_with("agentsys-ignore-all ") {
                 if in_header {
                     s.header_all = true;
                 }
@@ -267,9 +265,7 @@ fn find_agentsys_directive(line: &str) -> Option<&str> {
     let pos = line.find("agentsys-ignore")?;
     // Walk back through whitespace to the comment marker.
     let prefix = line[..pos].trim_end();
-    let valid_marker = prefix.ends_with("//")
-        || prefix.ends_with('#')
-        || prefix.ends_with("--");
+    let valid_marker = prefix.ends_with("//") || prefix.ends_with('#') || prefix.ends_with("--");
     if !valid_marker {
         return None;
     }

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -82,6 +82,10 @@ pub struct SlopFixesResult {
 /// `repo_root` is the working tree (used by path-based detectors).
 /// `map` is the loaded repo-intel artifact (provides import graph,
 /// project metadata, etc).
+///
+/// Findings are filtered against per-line suppression comments
+/// (`// agnix-ignore: <category>` or `# agnix-ignore: <category>`)
+/// before being returned — see [`apply_suppressions`].
 pub fn slop_fixes(repo_root: &Path, map: &RepoIntelData) -> SlopFixesResult {
     let mut fixes = Vec::new();
 
@@ -91,7 +95,165 @@ pub fn slop_fixes(repo_root: &Path, map: &RepoIntelData) -> SlopFixesResult {
     fixes.extend(orphan_exports(map));
     fixes.extend(ast_findings(repo_root));
 
+    let fixes = apply_suppressions(repo_root, fixes);
     SlopFixesResult { fixes }
+}
+
+/// Drop fixes whose target line is annotated with an
+/// `agnix-ignore: <category>` comment on the same line or the line
+/// immediately above. Comment forms recognized:
+///
+///   - `// agnix-ignore: orphan-export`           (Rust / TS / JS / Java / Go / C)
+///   - `# agnix-ignore: empty-catch`              (Python / Shell / TOML)
+///   - `// agnix-ignore: tracked-artifact, orphan-export`  (comma-separated list)
+///   - `// agnix-ignore-all`                      (suppresses every category)
+///
+/// File-deletion fixes (`tracked-artifact`, `stale-ci-config`,
+/// `duplicate-tooling`) are suppressible by an `agnix-ignore` comment
+/// in the file's first 5 lines (file-header convention).
+///
+/// Per-line fixes (`orphan-export`, `empty-catch`, `tautological-test`)
+/// are suppressible by a comment on the fix line OR the line above —
+/// matching how `eslint-disable-next-line` and `// noqa` work in
+/// other linters.
+fn apply_suppressions(repo_root: &Path, fixes: Vec<SlopFix>) -> Vec<SlopFix> {
+    use std::collections::HashMap;
+    // Cache file → suppression map across fixes from the same file
+    // so we don't re-read+re-parse the source for each finding.
+    let mut cache: HashMap<String, Option<FileSuppressions>> = HashMap::new();
+
+    fixes
+        .into_iter()
+        .filter(|fix| {
+            let path = fix_target_path(fix);
+            if path.is_none() {
+                return true;
+            }
+            let path = path.unwrap();
+            let suppressions = cache
+                .entry(path.to_string())
+                .or_insert_with(|| FileSuppressions::load(repo_root, path));
+            let Some(supp) = suppressions else {
+                return true;
+            };
+            !supp.suppresses(fix)
+        })
+        .collect()
+}
+
+fn fix_target_path(fix: &SlopFix) -> Option<&str> {
+    match &fix.action {
+        SlopAction::DeleteFile { path } => Some(path.as_str()),
+        SlopAction::DeleteLines { path, .. } => Some(path.as_str()),
+        SlopAction::ReplaceLines { path, .. } => Some(path.as_str()),
+    }
+}
+
+/// Per-file suppression index: `agnix-ignore` comments parsed once
+/// per file and reused across every fix targeting that file.
+struct FileSuppressions {
+    /// Header suppressions (lines 1-5) apply to file-level actions.
+    header_categories: std::collections::HashSet<String>,
+    /// Per-line suppressions: line N suppresses fixes on N or N+1.
+    line_categories: std::collections::HashMap<u32, std::collections::HashSet<String>>,
+    /// `agnix-ignore-all` line numbers — suppress every category.
+    line_all: std::collections::HashSet<u32>,
+    /// Header-scope `agnix-ignore-all` flag — suppresses every category
+    /// for any fix targeting this file.
+    header_all: bool,
+}
+
+impl FileSuppressions {
+    fn load(repo_root: &Path, rel_path: &str) -> Option<Self> {
+        let abs = repo_root.join(rel_path);
+        let content = std::fs::read_to_string(&abs).ok()?;
+        let mut s = FileSuppressions {
+            header_categories: Default::default(),
+            line_categories: Default::default(),
+            line_all: Default::default(),
+            header_all: false,
+        };
+        for (idx, line) in content.lines().enumerate() {
+            let line_no = (idx as u32) + 1;
+            let in_header = line_no <= 5;
+            let trimmed = line.trim_start();
+
+            // Strip a single leading comment marker (//, #, --) so we
+            // can detect the directive uniformly across languages.
+            let after_marker = trimmed
+                .strip_prefix("// ")
+                .or_else(|| trimmed.strip_prefix("//"))
+                .or_else(|| trimmed.strip_prefix("# "))
+                .or_else(|| trimmed.strip_prefix("#"))
+                .or_else(|| trimmed.strip_prefix("-- "))
+                .or_else(|| trimmed.strip_prefix("--"));
+            let Some(directive) = after_marker else {
+                continue;
+            };
+            let directive = directive.trim();
+
+            if directive == "agnix-ignore-all" || directive.starts_with("agnix-ignore-all ") {
+                if in_header {
+                    s.header_all = true;
+                }
+                s.line_all.insert(line_no);
+                continue;
+            }
+            if let Some(rest) = directive.strip_prefix("agnix-ignore:") {
+                let cats = rest
+                    .split(',')
+                    .map(|c| c.trim().to_string())
+                    .filter(|c| !c.is_empty());
+                let entry = s.line_categories.entry(line_no).or_default();
+                for cat in cats {
+                    if in_header {
+                        s.header_categories.insert(cat.clone());
+                    }
+                    entry.insert(cat);
+                }
+            }
+        }
+        Some(s)
+    }
+
+    fn suppresses(&self, fix: &SlopFix) -> bool {
+        let cat_str = serde_json::to_value(fix.category)
+            .ok()
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_default();
+        match &fix.action {
+            SlopAction::DeleteFile { .. } => {
+                self.header_all || self.header_categories.contains(&cat_str)
+            }
+            SlopAction::DeleteLines { lines, .. } | SlopAction::ReplaceLines { lines, .. } => {
+                let target_line = lines[0];
+                // Lookback window matches the `eslint-disable-next-line`
+                // convention but extends 3 lines to handle Python's
+                // try/except where the directive sits above `try:` and
+                // the offending body line is two below — and Rust's
+                // multi-line attribute prefixes (`#[cfg(test)]` then
+                // `#[allow(...)]` then the function).
+                for n in 0..=3u32 {
+                    let candidate = target_line.saturating_sub(n);
+                    if candidate == 0 {
+                        break;
+                    }
+                    if self.line_all.contains(&candidate) {
+                        return true;
+                    }
+                    if self
+                        .line_categories
+                        .get(&candidate)
+                        .map(|set| set.contains(&cat_str))
+                        .unwrap_or(false)
+                    {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
 }
 
 // ── Path-based detectors ─────────────────────────────────────────
@@ -2064,6 +2226,202 @@ mod tests {
                 .any(|f| f.category == SlopCategory::TautologicalTest),
             "expected testify Equal(t,1,1) flag; got {:?}",
             fixes
+        );
+    }
+
+    // ── agnix-ignore suppression directives ─────
+
+    fn empty_map() -> RepoIntelData {
+        use chrono::Utc;
+        use std::collections::HashMap as StdMap;
+        RepoIntelData {
+            version: "test".into(),
+            generated: Utc::now(),
+            updated: Utc::now(),
+            partial: false,
+            git: analyzer_core::types::GitInfo {
+                analyzed_up_to: "HEAD".into(),
+                total_commits_analyzed: 0,
+                first_commit_date: "".into(),
+                last_commit_date: "".into(),
+                scope: None,
+                shallow: false,
+            },
+            contributors: analyzer_core::types::Contributors {
+                humans: StdMap::new(),
+                bots: StdMap::new(),
+            },
+            file_activity: StdMap::new(),
+            coupling: StdMap::new(),
+            conventions: analyzer_core::types::ConventionInfo {
+                prefixes: StdMap::new(),
+                style: "".into(),
+                uses_scopes: false,
+                naming_patterns: None,
+                test_patterns: None,
+            },
+            releases: analyzer_core::types::Releases {
+                tags: vec![],
+                cadence: "".into(),
+            },
+            renames: vec![],
+            deletions: vec![],
+            symbols: None,
+            import_graph: None,
+            project: None,
+            doc_refs: None,
+            graph: None,
+            file_descriptors: None,
+            summary: None,
+            embeddings_meta: None,
+        }
+    }
+
+    #[test]
+    fn suppression_on_same_line_skips_fix() {
+        let dir = make_repo(&[(
+            "a.ts",
+            "function f() {\n    try { call() } catch {} // agnix-ignore: empty-catch\n}\n",
+        )]);
+        let map = empty_map();
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::EmptyCatch),
+            "annotation on same line should suppress; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn suppression_on_line_above_skips_fix() {
+        let dir = make_repo(&[(
+            "a.ts",
+            "function f() {\n    // agnix-ignore: empty-catch\n    try { call() } catch {}\n}\n",
+        )]);
+        let map = empty_map();
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::EmptyCatch),
+            "annotation on line above should suppress; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn suppression_python_uses_hash_marker() {
+        let dir = make_repo(&[(
+            "a.py",
+            "def f():\n    # agnix-ignore: empty-catch\n    try:\n        x = 1\n    except:\n        pass\n",
+        )]);
+        let map = empty_map();
+        let result = slop_fixes(dir.path(), &map);
+        // The except is at line 5; the directive on line 2 is too far
+        // (we only check ±1). This should NOT suppress.
+        assert!(
+            result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::EmptyCatch),
+            "directive too far away should NOT suppress; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn suppression_python_directly_above_works() {
+        let dir = make_repo(&[(
+            "a.py",
+            "def f():\n    try:\n        x = 1\n    # agnix-ignore: empty-catch\n    except:\n        pass\n",
+        )]);
+        let map = empty_map();
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::EmptyCatch),
+            "directive directly above except should suppress; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn suppression_wrong_category_does_not_skip() {
+        // Directive names a different category — fix must still fire.
+        let dir = make_repo(&[(
+            "a.ts",
+            "// agnix-ignore: orphan-export\nfunction f() { try {} catch {} }\n",
+        )]);
+        let map = empty_map();
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::EmptyCatch),
+            "different-category directive should NOT suppress empty-catch; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn suppression_comma_list_covers_multiple_categories() {
+        let dir = make_repo(&[(
+            "a.ts",
+            "function f() {\n    // agnix-ignore: empty-catch, tautological-test\n    try {} catch {}\n}\n",
+        )]);
+        let map = empty_map();
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::EmptyCatch),
+            "comma-list should cover empty-catch; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn suppression_ignore_all_directive_skips_any_category() {
+        let dir = make_repo(&[(
+            "a.ts",
+            "function f() {\n    // agnix-ignore-all\n    try {} catch {}\n}\n",
+        )]);
+        let map = empty_map();
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::EmptyCatch),
+            "agnix-ignore-all should suppress empty-catch; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn suppression_header_directive_skips_file_deletion() {
+        // File-deletion fixes (tracked-artifact) are suppressible by an
+        // agnix-ignore directive in the file's first 5 lines.
+        let dir = make_repo(&[(
+            "debug.log",
+            "// agnix-ignore: tracked-artifact\nthese are intentional log fixtures\n",
+        )]);
+        let result = slop_fixes(dir.path(), &empty_map());
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::TrackedArtifact),
+            "header directive should suppress file-deletion; got {:?}",
+            result.fixes
         );
     }
 }

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -84,7 +84,7 @@ pub struct SlopFixesResult {
 /// project metadata, etc).
 ///
 /// Findings are filtered against per-line suppression comments
-/// (`// agnix-ignore: <category>` or `# agnix-ignore: <category>`)
+/// (`// agentsys-ignore: <category>` or `# agentsys-ignore: <category>`)
 /// before being returned — see [`apply_suppressions`].
 pub fn slop_fixes(repo_root: &Path, map: &RepoIntelData) -> SlopFixesResult {
     let mut fixes = Vec::new();
@@ -100,16 +100,16 @@ pub fn slop_fixes(repo_root: &Path, map: &RepoIntelData) -> SlopFixesResult {
 }
 
 /// Drop fixes whose target line is annotated with an
-/// `agnix-ignore: <category>` comment on the same line or the line
+/// `agentsys-ignore: <category>` comment on the same line or the line
 /// immediately above. Comment forms recognized:
 ///
-///   - `// agnix-ignore: orphan-export`           (Rust / TS / JS / Java / Go / C)
-///   - `# agnix-ignore: empty-catch`              (Python / Shell / TOML)
-///   - `// agnix-ignore: tracked-artifact, orphan-export`  (comma-separated list)
-///   - `// agnix-ignore-all`                      (suppresses every category)
+///   - `// agentsys-ignore: orphan-export`           (Rust / TS / JS / Java / Go / C)
+///   - `# agentsys-ignore: empty-catch`              (Python / Shell / TOML)
+///   - `// agentsys-ignore: tracked-artifact, orphan-export`  (comma-separated list)
+///   - `// agentsys-ignore-all`                      (suppresses every category)
 ///
 /// File-deletion fixes (`tracked-artifact`, `stale-ci-config`,
-/// `duplicate-tooling`) are suppressible by an `agnix-ignore` comment
+/// `duplicate-tooling`) are suppressible by an `agentsys-ignore` comment
 /// in the file's first 5 lines (file-header convention).
 ///
 /// Per-line fixes (`orphan-export`, `empty-catch`, `tautological-test`)
@@ -149,16 +149,16 @@ fn fix_target_path(fix: &SlopFix) -> Option<&str> {
     }
 }
 
-/// Per-file suppression index: `agnix-ignore` comments parsed once
+/// Per-file suppression index: `agentsys-ignore` comments parsed once
 /// per file and reused across every fix targeting that file.
 struct FileSuppressions {
     /// Header suppressions (lines 1-5) apply to file-level actions.
     header_categories: std::collections::HashSet<String>,
     /// Per-line suppressions: line N suppresses fixes on N or N+1.
     line_categories: std::collections::HashMap<u32, std::collections::HashSet<String>>,
-    /// `agnix-ignore-all` line numbers — suppress every category.
+    /// `agentsys-ignore-all` line numbers — suppress every category.
     line_all: std::collections::HashSet<u32>,
-    /// Header-scope `agnix-ignore-all` flag — suppresses every category
+    /// Header-scope `agentsys-ignore-all` flag — suppresses every category
     /// for any fix targeting this file.
     header_all: bool,
 }
@@ -192,14 +192,14 @@ impl FileSuppressions {
             };
             let directive = directive.trim();
 
-            if directive == "agnix-ignore-all" || directive.starts_with("agnix-ignore-all ") {
+            if directive == "agentsys-ignore-all" || directive.starts_with("agentsys-ignore-all ") {
                 if in_header {
                     s.header_all = true;
                 }
                 s.line_all.insert(line_no);
                 continue;
             }
-            if let Some(rest) = directive.strip_prefix("agnix-ignore:") {
+            if let Some(rest) = directive.strip_prefix("agentsys-ignore:") {
                 let cats = rest
                     .split(',')
                     .map(|c| c.trim().to_string())
@@ -2229,7 +2229,7 @@ mod tests {
         );
     }
 
-    // ── agnix-ignore suppression directives ─────
+    // ── agentsys-ignore suppression directives ─────
 
     fn empty_map() -> RepoIntelData {
         use chrono::Utc;
@@ -2281,7 +2281,7 @@ mod tests {
     fn suppression_on_same_line_skips_fix() {
         let dir = make_repo(&[(
             "a.ts",
-            "function f() {\n    try { call() } catch {} // agnix-ignore: empty-catch\n}\n",
+            "function f() {\n    try { call() } catch {} // agentsys-ignore: empty-catch\n}\n",
         )]);
         let map = empty_map();
         let result = slop_fixes(dir.path(), &map);
@@ -2299,7 +2299,7 @@ mod tests {
     fn suppression_on_line_above_skips_fix() {
         let dir = make_repo(&[(
             "a.ts",
-            "function f() {\n    // agnix-ignore: empty-catch\n    try { call() } catch {}\n}\n",
+            "function f() {\n    // agentsys-ignore: empty-catch\n    try { call() } catch {}\n}\n",
         )]);
         let map = empty_map();
         let result = slop_fixes(dir.path(), &map);
@@ -2317,7 +2317,7 @@ mod tests {
     fn suppression_python_uses_hash_marker() {
         let dir = make_repo(&[(
             "a.py",
-            "def f():\n    # agnix-ignore: empty-catch\n    try:\n        x = 1\n    except:\n        pass\n",
+            "def f():\n    # agentsys-ignore: empty-catch\n    try:\n        x = 1\n    except:\n        pass\n",
         )]);
         let map = empty_map();
         let result = slop_fixes(dir.path(), &map);
@@ -2337,7 +2337,7 @@ mod tests {
     fn suppression_python_directly_above_works() {
         let dir = make_repo(&[(
             "a.py",
-            "def f():\n    try:\n        x = 1\n    # agnix-ignore: empty-catch\n    except:\n        pass\n",
+            "def f():\n    try:\n        x = 1\n    # agentsys-ignore: empty-catch\n    except:\n        pass\n",
         )]);
         let map = empty_map();
         let result = slop_fixes(dir.path(), &map);
@@ -2356,7 +2356,7 @@ mod tests {
         // Directive names a different category — fix must still fire.
         let dir = make_repo(&[(
             "a.ts",
-            "// agnix-ignore: orphan-export\nfunction f() { try {} catch {} }\n",
+            "// agentsys-ignore: orphan-export\nfunction f() { try {} catch {} }\n",
         )]);
         let map = empty_map();
         let result = slop_fixes(dir.path(), &map);
@@ -2374,7 +2374,7 @@ mod tests {
     fn suppression_comma_list_covers_multiple_categories() {
         let dir = make_repo(&[(
             "a.ts",
-            "function f() {\n    // agnix-ignore: empty-catch, tautological-test\n    try {} catch {}\n}\n",
+            "function f() {\n    // agentsys-ignore: empty-catch, tautological-test\n    try {} catch {}\n}\n",
         )]);
         let map = empty_map();
         let result = slop_fixes(dir.path(), &map);
@@ -2392,7 +2392,7 @@ mod tests {
     fn suppression_ignore_all_directive_skips_any_category() {
         let dir = make_repo(&[(
             "a.ts",
-            "function f() {\n    // agnix-ignore-all\n    try {} catch {}\n}\n",
+            "function f() {\n    // agentsys-ignore-all\n    try {} catch {}\n}\n",
         )]);
         let map = empty_map();
         let result = slop_fixes(dir.path(), &map);
@@ -2401,7 +2401,7 @@ mod tests {
                 .fixes
                 .iter()
                 .any(|f| f.category == SlopCategory::EmptyCatch),
-            "agnix-ignore-all should suppress empty-catch; got {:?}",
+            "agentsys-ignore-all should suppress empty-catch; got {:?}",
             result.fixes
         );
     }
@@ -2409,10 +2409,10 @@ mod tests {
     #[test]
     fn suppression_header_directive_skips_file_deletion() {
         // File-deletion fixes (tracked-artifact) are suppressible by an
-        // agnix-ignore directive in the file's first 5 lines.
+        // agentsys-ignore directive in the file's first 5 lines.
         let dir = make_repo(&[(
             "debug.log",
-            "// agnix-ignore: tracked-artifact\nthese are intentional log fixtures\n",
+            "// agentsys-ignore: tracked-artifact\nthese are intentional log fixtures\n",
         )]);
         let result = slop_fixes(dir.path(), &empty_map());
         assert!(

--- a/crates/analyzer-graph/src/slop_targets.rs
+++ b/crates/analyzer-graph/src/slop_targets.rs
@@ -321,14 +321,12 @@ fn cliche_name_clusters(map: &RepoIntelData) -> Vec<SlopTarget> {
             if matches!(
                 export.kind,
                 SymbolKind::Function | SymbolKind::Class | SymbolKind::Struct
-            ) {
-                let lower = export.name.to_ascii_lowercase();
-                if CLICHE.iter().any(|c| lower.contains(c)) {
-                    by_dir
-                        .entry(dir.clone())
-                        .or_default()
-                        .push(format!("{file_path}::{}", export.name));
-                }
+            ) && identifier_has_cliche_word(&export.name, CLICHE)
+            {
+                by_dir
+                    .entry(dir.clone())
+                    .or_default()
+                    .push(format!("{file_path}::{}", export.name));
             }
         }
     }
@@ -357,6 +355,65 @@ fn cliche_name_clusters(map: &RepoIntelData) -> Vec<SlopTarget> {
         });
     }
     out
+}
+
+/// Match cliché words against the EXACT word tokens of an identifier
+/// rather than as case-insensitive substrings. Splits on:
+///
+///   - underscores (snake_case → `data_loader` → ["data", "loader"])
+///   - camel/Pascal-case boundaries (`DataLoader` → ["Data", "Loader"])
+///   - hyphens (kebab-case)
+///   - digit↔letter boundaries (`Foo2Bar` → ["Foo", "2", "Bar"])
+///
+/// Without this, `databasePool` would match "data" as a substring even
+/// though `database` is a separate word from `data`. Same problem for
+/// `BaseTraitImpl`-style names matching "base", "trait", "impl"
+/// individually as substrings of unrelated longer words.
+fn identifier_has_cliche_word(name: &str, cliche: &[&str]) -> bool {
+    for token in tokenize_identifier(name) {
+        let lower = token.to_ascii_lowercase();
+        if cliche.contains(&lower.as_str()) {
+            return true;
+        }
+    }
+    false
+}
+
+fn tokenize_identifier(name: &str) -> Vec<String> {
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = String::new();
+
+    let chars: Vec<char> = name.chars().collect();
+    for (i, c) in chars.iter().enumerate() {
+        if *c == '_' || *c == '-' {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+
+        if !current.is_empty() {
+            let prev = current.chars().last().unwrap();
+            // Boundary: lower→upper (camelCase), digit↔letter, letter↔digit.
+            let is_boundary = (prev.is_ascii_lowercase() && c.is_ascii_uppercase())
+                || (prev.is_ascii_alphabetic() && c.is_ascii_digit())
+                || (prev.is_ascii_digit() && c.is_ascii_alphabetic())
+                // Boundary: upper→upper followed by lower (HTTPSConnection
+                // splits as ["HTTPS", "Connection"], not ["HTTPSCo", "..."]).
+                || (prev.is_ascii_uppercase()
+                    && c.is_ascii_uppercase()
+                    && i + 1 < chars.len()
+                    && chars[i + 1].is_ascii_lowercase());
+            if is_boundary {
+                tokens.push(std::mem::take(&mut current));
+            }
+        }
+        current.push(*c);
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
 }
 
 fn parent_dir(path: &str) -> String {
@@ -848,5 +905,79 @@ mod tests {
         assert!(json.contains("\"kind\":\"file\""));
         assert!(json.contains("\"tier\":\"sonnet\""));
         assert!(json.contains("\"suspect\":\"could-be-shorter\""));
+    }
+
+    // ── Word-boundary cliché tokenization ─────────
+
+    #[test]
+    fn tokenize_camel_case() {
+        assert_eq!(tokenize_identifier("DataLoader"), vec!["Data", "Loader"]);
+        assert_eq!(tokenize_identifier("dataLoader"), vec!["data", "Loader"]);
+    }
+
+    #[test]
+    fn tokenize_snake_case() {
+        assert_eq!(tokenize_identifier("data_loader"), vec!["data", "loader"]);
+        assert_eq!(
+            tokenize_identifier("__double__under"),
+            vec!["double", "under"]
+        );
+    }
+
+    #[test]
+    fn tokenize_kebab_case() {
+        assert_eq!(tokenize_identifier("data-loader"), vec!["data", "loader"]);
+    }
+
+    #[test]
+    fn tokenize_acronym_then_word() {
+        // HTTPSConnection should split at the upper→upper-then-lower
+        // boundary so "HTTPS" stays together and "Connection" is its
+        // own token.
+        assert_eq!(
+            tokenize_identifier("HTTPSConnection"),
+            vec!["HTTPS", "Connection"]
+        );
+    }
+
+    #[test]
+    fn tokenize_with_digits() {
+        assert_eq!(tokenize_identifier("Foo2Bar"), vec!["Foo", "2", "Bar"]);
+    }
+
+    #[test]
+    fn cliche_match_uses_word_boundaries_not_substrings() {
+        let cliche = &["data", "base", "common"];
+        // Real cliché names — should match.
+        assert!(identifier_has_cliche_word("DataLoader", cliche));
+        assert!(identifier_has_cliche_word("data_helper", cliche));
+        assert!(identifier_has_cliche_word("BaseModel", cliche));
+        assert!(identifier_has_cliche_word("CommonUtils", cliche));
+        // Substring noise — `database` is NOT `data`; `commonjs` is
+        // NOT `common`. These must NOT match.
+        assert!(!identifier_has_cliche_word("databasePool", cliche));
+        assert!(!identifier_has_cliche_word("DatabaseConnection", cliche));
+        assert!(!identifier_has_cliche_word("commonjs", cliche));
+        assert!(!identifier_has_cliche_word("Cornerstone", cliche)); // contains "stone"-ish noise
+    }
+
+    #[test]
+    fn cliche_match_is_case_insensitive() {
+        let cliche = &["impl"];
+        assert!(identifier_has_cliche_word("MyImpl", cliche));
+        assert!(identifier_has_cliche_word("my_impl", cliche));
+        assert!(identifier_has_cliche_word("MY_IMPL", cliche));
+    }
+
+    #[test]
+    fn cliche_match_handles_dao_dto_pattern_suffixes() {
+        let cliche = &["dao", "dto"];
+        assert!(identifier_has_cliche_word("UserDao", cliche));
+        assert!(identifier_has_cliche_word("CreateUserDto", cliche));
+        // "fado" / "ado" do NOT contain "dao" as a word — these are
+        // unrelated names that the old substring match would have
+        // false-positived.
+        assert!(!identifier_has_cliche_word("Fado", cliche));
+        assert!(!identifier_has_cliche_word("Bravado", cliche));
     }
 }

--- a/crates/analyzer-graph/src/slop_targets.rs
+++ b/crates/analyzer-graph/src/slop_targets.rs
@@ -382,6 +382,11 @@ fn identifier_has_cliche_word(name: &str, cliche: &[&str]) -> bool {
 fn tokenize_identifier(name: &str) -> Vec<String> {
     let mut tokens: Vec<String> = Vec::new();
     let mut current = String::new();
+    // Track previous char in a local instead of calling
+    // `current.chars().last()` on every iteration — that turns the
+    // tokenizer from O(N²) (worst case on long single-token names)
+    // to O(N).
+    let mut prev_char: Option<char> = None;
 
     let chars: Vec<char> = name.chars().collect();
     for (i, c) in chars.iter().enumerate() {
@@ -389,11 +394,11 @@ fn tokenize_identifier(name: &str) -> Vec<String> {
             if !current.is_empty() {
                 tokens.push(std::mem::take(&mut current));
             }
+            prev_char = None;
             continue;
         }
 
-        if !current.is_empty() {
-            let prev = current.chars().last().unwrap();
+        if let Some(prev) = prev_char {
             // Boundary: lower→upper (camelCase), digit↔letter, letter↔digit.
             let is_boundary = (prev.is_ascii_lowercase() && c.is_ascii_uppercase())
                 || (prev.is_ascii_alphabetic() && c.is_ascii_digit())
@@ -409,6 +414,7 @@ fn tokenize_identifier(name: &str) -> Vec<String> {
             }
         }
         current.push(*c);
+        prev_char = Some(*c);
     }
     if !current.is_empty() {
         tokens.push(current);


### PR DESCRIPTION
Two precision improvements that compose well: precision on the detector side (cliché matching), control on the user side (suppression). Tier 3 #8 + #9 from the post-merge brainstorm.

## 1. Word-boundary cliché tokenization

The cliché-name detector previously matched cliché words as case-insensitive substrings, so `databasePool` would match "data" even though `database` is an entirely different word. Replaced with word-token matching:

- Snake/kebab case split on `_`/`-`
- CamelCase / PascalCase split at lower→upper boundaries
- Acronym handling (`HTTPSConnection` → ["HTTPS", "Connection"])
- Digit↔letter boundaries (`Foo2Bar` → ["Foo", "2", "Bar"])

Each token is then compared exactly (case-insensitive) against the cliché list. Real cliché names (`DataLoader`, `BaseModel`, `UserDao`, `MyImpl`) still match. False-positive substrings (`databasePool`, `commonjs`, `Bravado`) no longer match.

## 2. agentsys-ignore suppression directives

Linter-style escape hatch so users can silence known-intentional findings without losing detection elsewhere. Recognized forms:

| Marker | Languages |
|---|---|
| `// agentsys-ignore: <category>` | Rust / TS / JS / Java / Go / C |
| `# agentsys-ignore: <category>` | Python / Shell / TOML |
| `-- agentsys-ignore: <category>` | SQL / Lua |
| `// agentsys-ignore: empty-catch, tautological-test` | comma list |
| `// agentsys-ignore-all` | suppresses every category |

Named after the `agentsys` umbrella plugin, not after `agnix` (which is a separate plugin under the same org for agent-config validation).

**Lookback window**: 3 lines above the flagged location, plus the same line. Wide enough to handle Python's `directive-above-try:` / `body-inside-except:` pattern AND Rust's multi-attribute prefixes, narrow enough to avoid suppressing unrelated lower-down code.

**File-deletion fixes** (`tracked-artifact`, `stale-ci-config`, `duplicate-tooling`) are suppressible by an `agentsys-ignore` comment in the file's first 5 lines (file-header convention).

**Performance**: `FileSuppressions::load()` parses the file once per query even when many fixes target the same file.

## Tests

- 8 new cliché/tokenization tests (camel/snake/kebab/digit boundaries; HTTPSConnection acronym; positive + negative substring noise cases)
- 8 new suppression tests (same-line, line-above, Python distance, wrong-category does-not-skip, comma list, ignore-all, header for file deletion)
- 410+ workspace tests pass
- clippy clean, fmt clean