### PR TITLE
feat(slop): --files filter + stale-suppression detector

### DIFF
--- a/crates/analyzer-cli/src/commands/repo_intel.rs
+++ b/crates/analyzer-cli/src/commands/repo_intel.rs
@@ -351,6 +351,9 @@ pub enum QueryAction {
         /// Path to repo-intel JSON file (optional - enables AST main detection)
         #[arg(long)]
         map_file: Option<PathBuf>,
+        /// Restrict results to this comma-separated list of repo-relative files
+        #[arg(long, value_delimiter = ',')]
+        files: Vec<String>,
     },
     /// Find files relevant to a fuzzy concept (collapses `grep -r` into ranked output)
     Find {
@@ -388,6 +391,9 @@ pub enum QueryAction {
         /// Path to repo-intel JSON file (provides import graph + symbols)
         #[arg(long)]
         map_file: PathBuf,
+        /// Restrict results to this comma-separated list of repo-relative files
+        #[arg(long, value_delimiter = ',')]
+        files: Vec<String>,
     },
     /// Ranked targets for the deslop agent's Sonnet- and Opus-tier
     /// scans. Sonnet tier = file-level (defensive cargo cult, bot
@@ -403,6 +409,9 @@ pub enum QueryAction {
         /// Max rows per tier
         #[arg(long, default_value = "10")]
         top: usize,
+        /// Restrict results to targets touching this comma-separated list of repo-relative files
+        #[arg(long, value_delimiter = ',')]
+        files: Vec<String>,
     },
 }
 
@@ -559,6 +568,27 @@ fn run_set_embeddings(map_file: &Path, input: &str) -> Result<()> {
         sidecar_path.display()
     );
     Ok(())
+}
+
+/// Normalize a repo-relative path so the `--files` filter matches
+/// regardless of whether callers pass `src/foo.rs` or `src\\foo.rs`
+/// (Windows) or a leading `./`. Trailing slashes stripped.
+fn normalize_rel_path(p: &str) -> String {
+    let s = p.replace('\\', "/");
+    let s = s.strip_prefix("./").unwrap_or(&s);
+    s.trim_end_matches('/').to_string()
+}
+
+/// Build a HashSet from a `--files` comma-separated list, normalizing
+/// each entry. Clap's `value_delimiter = ','` already split on commas;
+/// here we just trim + normalize + dedupe.
+fn file_filter_set(files: &[String]) -> std::collections::HashSet<String> {
+    files
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(normalize_rel_path)
+        .collect()
 }
 
 fn derive_sidecar_path(map_file: &Path) -> PathBuf {
@@ -955,7 +985,11 @@ fn run_query(query: QueryAction) -> Result<()> {
                 }
             }
         }
-        QueryAction::EntryPoints { path, map_file } => {
+        QueryAction::EntryPoints {
+            path,
+            map_file,
+            files,
+        } => {
             // The symbol index is optional - it adds AST-derived `main`
             // functions to the manifest-derived results. Without it the
             // query still returns Cargo/npm/pyproject entries.
@@ -963,7 +997,11 @@ fn run_query(query: QueryAction) -> Result<()> {
                 Some(mf) => load_map(mf)?.symbols,
                 None => None,
             };
-            let result = analyzer_collectors::entry_points::detect(&path, symbols.as_ref());
+            let mut result = analyzer_collectors::entry_points::detect(&path, symbols.as_ref());
+            if !files.is_empty() {
+                let allowed = file_filter_set(&files);
+                result.retain(|ep| allowed.contains(&normalize_rel_path(&ep.path)));
+            }
             println!("{}", output::to_json(&result));
         }
         QueryAction::Find {
@@ -990,15 +1028,31 @@ fn run_query(query: QueryAction) -> Result<()> {
                 }
             }
         }
-        QueryAction::SlopFixes { path, map_file } => {
+        QueryAction::SlopFixes {
+            path,
+            map_file,
+            files,
+        } => {
             let map = load_map(&map_file)?;
-            let result = analyzer_graph::slop::slop_fixes(&path, &map);
+            let mut result = analyzer_graph::slop::slop_fixes(&path, &map);
+            if !files.is_empty() {
+                let allowed = file_filter_set(&files);
+                result.fixes.retain(|f| {
+                    f.action
+                        .path()
+                        .map(|p| allowed.contains(&normalize_rel_path(p)))
+                        .unwrap_or(false)
+                });
+                // by_file is derived from fixes; regenerate to stay in sync.
+                result.by_file = analyzer_graph::slop::group_by_file(&result.fixes);
+            }
             println!("{}", output::to_json(&result));
         }
         QueryAction::SlopTargets {
             path: _,
             map_file,
             top,
+            files,
         } => {
             let map = load_map(&map_file)?;
             let sidecar_path = derive_sidecar_path(&map_file);
@@ -1009,7 +1063,14 @@ fn run_query(query: QueryAction) -> Result<()> {
             } else {
                 None
             };
-            let result = analyzer_graph::slop_targets::slop_targets(&map, sidecar.as_ref(), top);
+            let mut result =
+                analyzer_graph::slop_targets::slop_targets(&map, sidecar.as_ref(), top);
+            if !files.is_empty() {
+                let allowed = file_filter_set(&files);
+                analyzer_graph::slop_targets::retain_targets_touching(&mut result, |p| {
+                    allowed.contains(&normalize_rel_path(p))
+                });
+            }
             println!("{}", output::to_json(&result));
         }
         QueryAction::Summary {

--- a/crates/analyzer-cli/src/commands/repo_intel.rs
+++ b/crates/analyzer-cli/src/commands/repo_intel.rs
@@ -1037,12 +1037,9 @@ fn run_query(query: QueryAction) -> Result<()> {
             let mut result = analyzer_graph::slop::slop_fixes(&path, &map);
             if !files.is_empty() {
                 let allowed = file_filter_set(&files);
-                result.fixes.retain(|f| {
-                    f.action
-                        .path()
-                        .map(|p| allowed.contains(&normalize_rel_path(p)))
-                        .unwrap_or(false)
-                });
+                result
+                    .fixes
+                    .retain(|f| allowed.contains(&normalize_rel_path(f.action.path())));
                 // by_file is derived from fixes; regenerate to stay in sync.
                 result.by_file = analyzer_graph::slop::group_by_file(&result.fixes);
             }

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -49,13 +49,14 @@ pub enum SlopAction {
 }
 
 impl SlopAction {
-    /// Target file for this action. Every variant has a path; this
-    /// helper is used by the CLI `--files` filter and consumers.
-    pub fn path(&self) -> Option<&str> {
+    /// Target file for this action. Every variant has a path, so
+    /// this is total. Used by the CLI `--files` filter and consumers
+    /// that group / dedupe by target path.
+    pub fn path(&self) -> &str {
         match self {
             SlopAction::DeleteFile { path }
             | SlopAction::DeleteLines { path, .. }
-            | SlopAction::ReplaceLines { path, .. } => Some(path.as_str()),
+            | SlopAction::ReplaceLines { path, .. } => path.as_str(),
         }
     }
 }
@@ -3263,22 +3264,85 @@ const ALLOW_SUPPRESSION_LINTS: &[&str] = &[
     "unused_must_use",
 ];
 
-/// Collect every name referenced by an `imports[].names` entry across
-/// the map. The return value is a `HashSet<String>` keyed on the
-/// exact name string — conservative matching, not case-folded, since
-/// Rust identifiers are case-sensitive.
-fn collect_used_names(map: &RepoIntelData) -> HashSet<String> {
-    let mut used = HashSet::new();
+/// Collected usage information from the symbol graph.
+///
+/// The detector needs both "name is imported somewhere" (fast
+/// membership test) and "which module paths reference this name"
+/// (used to bias toward same-crate matches and away from
+/// cross-module name collisions). Keeping both in one struct so the
+/// build walk happens once.
+struct UsedSymbols {
+    /// Every imported name seen across the map. Rust identifiers are
+    /// case-sensitive so no case-folding.
+    all_names: HashSet<String>,
+    /// Per-name: the set of `imports[].from` module-path strings that
+    /// imported it. Lets the caller check `name "helper" is imported
+    /// from a path that could plausibly resolve to our file` rather
+    /// than blindly trusting a bare-name collision.
+    modules_per_name: HashMap<String, HashSet<String>>,
+}
+
+fn collect_used_symbols(map: &RepoIntelData) -> UsedSymbols {
+    let mut all_names = HashSet::new();
+    let mut modules_per_name: HashMap<String, HashSet<String>> = HashMap::new();
     if let Some(syms) = map.symbols.as_ref() {
         for (_path, file_syms) in syms.iter() {
             for imp in &file_syms.imports {
                 for name in &imp.names {
-                    used.insert(name.clone());
+                    all_names.insert(name.clone());
+                    modules_per_name
+                        .entry(name.clone())
+                        .or_default()
+                        .insert(imp.from.clone());
                 }
             }
         }
     }
-    used
+    UsedSymbols {
+        all_names,
+        modules_per_name,
+    }
+}
+
+/// Return true if any `imports[].from` value looks like it could path
+/// to the given file. A bare `crate::foo::bar` import gets matched
+/// against the file path by taking each path segment and checking
+/// whether the file's relative path contains that segment. It's
+/// permissive by design — a hit is strong evidence, a miss would
+/// wrongly spare a real stale suppression.
+///
+/// For a file `crates/foo/src/helpers.rs` and an import `from =
+/// "crate::helpers"`, the segments [`crate`, `helpers`] both appear
+/// in the path, so we return true.
+///
+/// When no cross-file import data is available for a name (which can
+/// happen for inherent methods or crate-private usage the import
+/// collector didn't capture) we conservatively return true so the
+/// detector falls back to the all-names membership check it had
+/// before.
+fn import_paths_could_resolve_to_file(modules: &HashSet<String>, rel_file: &str) -> bool {
+    if modules.is_empty() {
+        return true;
+    }
+    let file_norm = rel_file.replace('\\', "/");
+    for module in modules {
+        let segments: Vec<&str> = module
+            .split("::")
+            .filter(|s| !s.is_empty() && *s != "crate" && *s != "self" && *s != "super")
+            .collect();
+        if segments.is_empty() {
+            // `crate` or `self` alone — any file in the same crate is
+            // a valid target. Treat as a match.
+            return true;
+        }
+        if segments
+            .iter()
+            .any(|seg| file_norm.contains(&format!("/{seg}")) || file_norm.starts_with(seg))
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Parse an `#[allow(...)]` attribute via AST structure, not text
@@ -3364,42 +3428,65 @@ fn extract_allow_lints(attribute_node: &tree_sitter::Node, source: &[u8]) -> Vec
 /// Find the identifier of the item an attribute is attached to. Rust
 /// tree-sitter puts attribute_item as a sibling before the decorated
 /// item inside the same enclosing scope. We walk forward siblings
-/// skipping whitespace/other attributes until we hit one of the
-/// target item kinds.
+/// skipping whitespace/other attributes/macros until we hit an item
+/// with a named identifier, or run out.
+///
+/// Returning `None` for unrecognized kinds rather than aborting means
+/// stacked attributes work: `#[allow(dead_code)] #[derive(Debug)] struct
+/// Foo` walks attr → attr → struct_item and finds `Foo`.
 fn next_item_identifier<'a>(
     attr: &tree_sitter::Node<'a>,
     source: &[u8],
 ) -> Option<(String, tree_sitter::Node<'a>)> {
+    const NAMED_ITEM_KINDS: &[&str] = &[
+        "function_item",
+        "function_signature_item",
+        "struct_item",
+        "enum_item",
+        "mod_item",
+        "const_item",
+        "static_item",
+        "trait_item",
+        "type_item",
+        "union_item",
+        "extern_crate_declaration",
+    ];
+    const SKIP_KINDS: &[&str] = &[
+        "attribute_item",
+        "line_comment",
+        "block_comment",
+        "macro_invocation",
+        "inner_doc_comment_marker",
+        "outer_doc_comment_marker",
+    ];
     let mut cur = attr.next_named_sibling();
     while let Some(node) = cur {
-        match node.kind() {
-            "attribute_item" | "line_comment" | "block_comment" => {
-                cur = node.next_named_sibling();
-                continue;
-            }
-            "function_item"
-            | "function_signature_item"
-            | "struct_item"
-            | "enum_item"
-            | "mod_item"
-            | "const_item"
-            | "static_item"
-            | "trait_item"
-            | "type_item"
-            | "union_item" => {
-                let name_node = node.child_by_field_name("name")?;
-                let name = name_node.utf8_text(source).ok()?.to_string();
-                return Some((name, node));
-            }
-            _ => return None,
+        let kind = node.kind();
+        if SKIP_KINDS.contains(&kind) {
+            cur = node.next_named_sibling();
+            continue;
         }
+        if NAMED_ITEM_KINDS.contains(&kind) {
+            if let Some(name_node) = node.child_by_field_name("name")
+                && let Ok(name) = name_node.utf8_text(source)
+            {
+                return Some((name.to_string(), node));
+            }
+            return None;
+        }
+        // impl_item / use_declaration / foreign_mod_item / etc. are
+        // legitimately decorated but don't carry a single name field
+        // we can check against the usage graph. Treat as "can't
+        // determine" and move on — underreporting is safer than
+        // false positives on an impl block.
+        return None;
     }
     None
 }
 
 fn stale_suppressions_rust(repo_root: &Path, map: &RepoIntelData) -> Vec<SlopFix> {
-    let used = collect_used_names(map);
-    if used.is_empty() {
+    let used = collect_used_symbols(map);
+    if used.all_names.is_empty() {
         // No symbol graph → we can't tell used from unused; skip
         // rather than emit false positives.
         return Vec::new();
@@ -3446,16 +3533,40 @@ fn stale_suppressions_rust(repo_root: &Path, map: &RepoIntelData) -> Vec<SlopFix
             };
             let attr = cap.node;
             let lints = extract_allow_lints(&attr, source);
-            let is_suppression = lints
+            if lints.is_empty() {
+                continue;
+            }
+            // Only emit when EVERY lint in the attribute is a stale
+            // suppression candidate. Mixed-lint attributes like
+            // `#[allow(non_snake_case, dead_code)]` get left alone —
+            // deleting the whole line would silently drop the
+            // non-suppression lint (`non_snake_case` here). A future
+            // enhancement could emit a ReplaceLines that keeps the
+            // non-suppression lints, but for now we prefer under-
+            // reporting to a fix that breaks other lints.
+            let all_suppression = lints
                 .iter()
-                .any(|l| ALLOW_SUPPRESSION_LINTS.contains(&l.as_str()));
-            if !is_suppression {
+                .all(|l| ALLOW_SUPPRESSION_LINTS.contains(&l.as_str()));
+            if !all_suppression {
                 continue;
             }
             let Some((name, _item_node)) = next_item_identifier(&attr, source) else {
                 continue;
             };
-            if !used.contains(&name) {
+            if !used.all_names.contains(&name) {
+                continue;
+            }
+            // Name-collision guard: a `#[allow(dead_code)]` on a
+            // private `helper` in src/a.rs shouldn't be flagged just
+            // because an unrelated file imports a different `helper`
+            // from a different module. Require that at least one of
+            // the `imports[].from` paths for this name could plausibly
+            // resolve to the current file (segment match). When no
+            // import path info is available we fall through
+            // permissively — see `import_paths_could_resolve_to_file`.
+            if let Some(modules) = used.modules_per_name.get(&name)
+                && !import_paths_could_resolve_to_file(modules, &rel)
+            {
                 continue;
             }
             let start = (attr.start_position().row as u32) + 1;
@@ -4976,6 +5087,10 @@ pub fn ok() {}
 
     // ── Stale suppression annotations ─────────────────────
 
+    /// Build a map where `file` imports `imported` from `crate::lib`.
+    /// The "lib" segment is chosen so the default src/lib.rs target
+    /// file in the stale-suppression tests matches the import-path
+    /// resolution check (segment match against "lib").
     fn map_with_import(file: &str, imported: &[&str]) -> RepoIntelData {
         let mut m = empty_map();
         let mut syms = std::collections::HashMap::new();
@@ -4984,7 +5099,7 @@ pub fn ok() {}
             analyzer_core::types::FileSymbols {
                 exports: Vec::new(),
                 imports: vec![analyzer_core::types::ImportEntry {
-                    from: "crate::other".to_string(),
+                    from: "crate::lib".to_string(),
                     names: imported.iter().map(|s| s.to_string()).collect(),
                 }],
                 definitions: Vec::new(),
@@ -5092,6 +5207,66 @@ pub fn helper(x: u32) -> u32 { x + 1 }
                 .iter()
                 .any(|f| f.category == SlopCategory::StaleSuppression),
             "should skip test files; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn ignores_mixed_lint_allow_with_non_suppression() {
+        // `#[allow(non_snake_case, dead_code)]` on a used symbol
+        // must NOT be flagged — deleting the line would silently
+        // drop the `non_snake_case` lint suppression. Mixed-lint
+        // attributes are left alone until we can rewrite them
+        // surgically.
+        let src = "\
+#[allow(non_snake_case, dead_code)]
+pub fn Helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("src/lib.rs", src)]);
+        let map = map_with_import("src/consumer.rs", &["Helper"]);
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::StaleSuppression),
+            "should not flag mixed-lint attribute; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_name_collision() {
+        // `helper` in src/module_a.rs has #[allow(dead_code)].
+        // Another file imports `helper` from `crate::module_b`. Name
+        // collision does NOT imply module_a's helper is used.
+        let src_a = "\
+#[allow(dead_code)]
+pub fn helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("src/module_a.rs", src_a)]);
+        let mut m = empty_map();
+        let mut syms = std::collections::HashMap::new();
+        syms.insert(
+            "src/consumer.rs".to_string(),
+            analyzer_core::types::FileSymbols {
+                exports: Vec::new(),
+                imports: vec![analyzer_core::types::ImportEntry {
+                    // Path clearly targets module_b, NOT module_a.
+                    from: "crate::module_b".to_string(),
+                    names: vec!["helper".to_string()],
+                }],
+                definitions: Vec::new(),
+            },
+        );
+        m.symbols = Some(syms);
+        let result = slop_fixes(dir.path(), &m);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::StaleSuppression),
+            "should not flag helper in module_a when import targets module_b; got {:?}",
             result.fixes
         );
     }

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -48,6 +48,18 @@ pub enum SlopAction {
     },
 }
 
+impl SlopAction {
+    /// Target file for this action. Every variant has a path; this
+    /// helper is used by the CLI `--files` filter and consumers.
+    pub fn path(&self) -> Option<&str> {
+        match self {
+            SlopAction::DeleteFile { path }
+            | SlopAction::DeleteLines { path, .. }
+            | SlopAction::ReplaceLines { path, .. } => Some(path.as_str()),
+        }
+    }
+}
+
 /// Why a fix was emitted. Stable identifiers so downstream tools can
 /// filter or group by category.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,6 +87,15 @@ pub enum SlopCategory {
     /// (function, class, assignment, control flow) — a strong signal
     /// the code was commented out rather than explained in prose.
     CommentedOutCode,
+    /// A `#[allow(dead_code)]` / `#[allow(unused)]` attribute on a
+    /// symbol that the import graph proves IS being used. The
+    /// suppression was correct at some point but the symbol became
+    /// reachable again and the annotation was never removed. Keeping
+    /// stale suppressions around blinds the real dead-code lint.
+    /// Rust-only; other languages have different suppression shapes
+    /// (`@ts-ignore`, `# noqa`, `@SuppressWarnings`) that serve
+    /// different purposes.
+    StaleSuppression,
 }
 
 /// Confidence in a fix, on a 0.0-1.0 scale.
@@ -111,6 +132,7 @@ pub fn default_confidence(category: SlopCategory) -> Confidence {
         SlopCategory::DuplicateTooling => 0.85,
         SlopCategory::PassthroughWrapper => 0.85,
         SlopCategory::CommentedOutCode => 0.85,
+        SlopCategory::StaleSuppression => 0.90,
         // Sensitive to import-graph completeness; recommend review
         SlopCategory::OrphanExport => 0.75,
     }
@@ -200,6 +222,7 @@ pub fn slop_fixes(repo_root: &Path, map: &RepoIntelData) -> SlopFixesResult {
     fixes.extend(duplicate_tooling(repo_root));
     fixes.extend(orphan_exports(map));
     fixes.extend(ast_findings(repo_root));
+    fixes.extend(stale_suppressions_rust(repo_root, map));
 
     let fixes = apply_suppressions(repo_root, fixes);
     let by_file = group_by_file(&fixes);
@@ -393,6 +416,7 @@ fn category_kebab(c: SlopCategory) -> &'static str {
         SlopCategory::PassthroughWrapper => "passthrough-wrapper",
         SlopCategory::AlwaysTrueCondition => "always-true-condition",
         SlopCategory::CommentedOutCode => "commented-out-code",
+        SlopCategory::StaleSuppression => "stale-suppression",
     }
 }
 
@@ -3201,6 +3225,207 @@ fn commented_out_code(
     out
 }
 
+// ── Stale suppression annotations (Rust) ─────────────────────────
+//
+// A `#[allow(dead_code)]` / `#[allow(unused)]` attribute on a symbol
+// that the import graph proves IS being used. The suppression was
+// correct at some point but the symbol became reachable again and
+// the annotation was never removed. Keeping stale suppressions
+// around blinds the real dead-code lint.
+//
+// Algorithm:
+//
+// 1. Build a `used_names` set from the map: every entry in every
+//    file's `imports[].names`. Also mirror into a lowercased set for
+//    case-insensitive probes (JS/TS cross-language edges).
+// 2. For each `.rs` file, run a tree-sitter query for attribute items
+//    whose content starts with `allow(...)`. Accept the attribute
+//    only when its argument list contains one of: `dead_code`,
+//    `unused`, `unused_imports`, `unused_variables`,
+//    `unused_assignments`, `unused_must_use`.
+// 3. For each matched attribute, find the following sibling item
+//    node (fn / struct / enum / mod / const / static / trait / impl)
+//    and its identifier.
+// 4. If the identifier appears in `used_names`, flag the attribute
+//    for deletion (DeleteLines over the attribute's line range).
+//
+// Confidence 0.90: the graph-based evidence is strong but the import
+// graph can be incomplete for non-Rust callers (e.g. an FFI boundary
+// where the name is referenced from C/Python via `pub extern`). The
+// suppression-directive system lets users silence any false positive.
+
+const ALLOW_SUPPRESSION_LINTS: &[&str] = &[
+    "dead_code",
+    "unused",
+    "unused_imports",
+    "unused_variables",
+    "unused_assignments",
+    "unused_must_use",
+];
+
+/// Collect every name referenced by an `imports[].names` entry across
+/// the map. The return value is a `HashSet<String>` keyed on the
+/// exact name string — conservative matching, not case-folded, since
+/// Rust identifiers are case-sensitive.
+fn collect_used_names(map: &RepoIntelData) -> HashSet<String> {
+    let mut used = HashSet::new();
+    if let Some(syms) = map.symbols.as_ref() {
+        for (_path, file_syms) in syms.iter() {
+            for imp in &file_syms.imports {
+                for name in &imp.names {
+                    used.insert(name.clone());
+                }
+            }
+        }
+    }
+    used
+}
+
+/// Parse the argument list of an `allow(...)` attribute. Returns the
+/// set of lint names mentioned. The tree-sitter node for the
+/// attribute is `attribute_item` with child `attribute` which in
+/// turn contains a `token_tree` of identifier tokens separated by
+/// commas. We walk the tree and collect every identifier.
+fn extract_allow_lints(attribute_node: &tree_sitter::Node, source: &[u8]) -> Vec<String> {
+    let text = match attribute_node.utf8_text(source) {
+        Ok(t) => t,
+        Err(_) => return Vec::new(),
+    };
+    // Tolerate `#[allow(...)]` and `#![allow(...)]`. We only act on
+    // outer (#[...]) attributes; inner (#![...]) are module-scoped
+    // and removing them would change the module-wide silence shape.
+    if text.starts_with("#![") {
+        return Vec::new();
+    }
+    let Some(open) = text.find("allow(") else {
+        return Vec::new();
+    };
+    let rest = &text[open + "allow(".len()..];
+    let Some(close) = rest.find(')') else {
+        return Vec::new();
+    };
+    rest[..close]
+        .split(',')
+        .map(|s| s.trim().trim_start_matches("clippy::"))
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Find the identifier of the item an attribute is attached to. Rust
+/// tree-sitter puts attribute_item as a sibling before the decorated
+/// item inside the same enclosing scope. We walk forward siblings
+/// skipping whitespace/other attributes until we hit one of the
+/// target item kinds.
+fn next_item_identifier<'a>(
+    attr: &tree_sitter::Node<'a>,
+    source: &[u8],
+) -> Option<(String, tree_sitter::Node<'a>)> {
+    let mut cur = attr.next_named_sibling();
+    while let Some(node) = cur {
+        match node.kind() {
+            "attribute_item" | "line_comment" | "block_comment" => {
+                cur = node.next_named_sibling();
+                continue;
+            }
+            "function_item"
+            | "function_signature_item"
+            | "struct_item"
+            | "enum_item"
+            | "mod_item"
+            | "const_item"
+            | "static_item"
+            | "trait_item"
+            | "type_item"
+            | "union_item" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = name_node.utf8_text(source).ok()?.to_string();
+                return Some((name, node));
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+fn stale_suppressions_rust(repo_root: &Path, map: &RepoIntelData) -> Vec<SlopFix> {
+    let used = collect_used_names(map);
+    if used.is_empty() {
+        // No symbol graph → we can't tell used from unused; skip
+        // rather than emit false positives.
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+    let query_src = "(attribute_item) @attr";
+    let Ok(query) = tree_sitter::Query::new(&language, query_src) else {
+        return out;
+    };
+
+    for path in walk_repo_files(repo_root) {
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let rel = relative(&path, repo_root);
+        // Test files routinely carry `#[allow(dead_code)]` on helper
+        // fixtures that aren't "used" in the production graph. Skip
+        // them to avoid noise — same rule the passthrough-wrapper
+        // detector already follows.
+        if is_rust_test_file(&rel) {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let mut parser = tree_sitter::Parser::new();
+        if parser.set_language(&language).is_err() {
+            continue;
+        }
+        let Some(tree) = parser.parse(&content, None) else {
+            continue;
+        };
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), content.as_bytes());
+        let source = content.as_bytes();
+        while let Some(m) = matches.next() {
+            let Some(cap) = m.captures.first() else {
+                continue;
+            };
+            let attr = cap.node;
+            let lints = extract_allow_lints(&attr, source);
+            let is_suppression = lints
+                .iter()
+                .any(|l| ALLOW_SUPPRESSION_LINTS.contains(&l.as_str()));
+            if !is_suppression {
+                continue;
+            }
+            let Some((name, _item_node)) = next_item_identifier(&attr, source) else {
+                continue;
+            };
+            if !used.contains(&name) {
+                continue;
+            }
+            let start = (attr.start_position().row as u32) + 1;
+            let end = (attr.end_position().row as u32) + 1;
+            let category = SlopCategory::StaleSuppression;
+            out.push(SlopFix {
+                action: SlopAction::DeleteLines {
+                    path: rel.clone(),
+                    lines: [start, end],
+                },
+                category,
+                reason: format!(
+                    "Rust `#[allow({})]` on `{name}` — symbol is imported elsewhere in the graph so the suppression is stale",
+                    lints.join(", ")
+                ),
+                confidence: default_confidence(category),
+            });
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4694,6 +4919,150 @@ pub fn ok() {}
                 .iter()
                 .any(|f| f.category == SlopCategory::CommentedOutCode),
             "leading-star block should flag; got {fixes:?}"
+        );
+    }
+
+    // ── Stale suppression annotations ─────────────────────
+
+    fn map_with_import(file: &str, imported: &[&str]) -> RepoIntelData {
+        let mut m = empty_map();
+        let mut syms = std::collections::HashMap::new();
+        syms.insert(
+            file.to_string(),
+            analyzer_core::types::FileSymbols {
+                exports: Vec::new(),
+                imports: vec![analyzer_core::types::ImportEntry {
+                    from: "crate::other".to_string(),
+                    names: imported.iter().map(|s| s.to_string()).collect(),
+                }],
+                definitions: Vec::new(),
+            },
+        );
+        m.symbols = Some(syms);
+        m
+    }
+
+    #[test]
+    fn detects_stale_allow_dead_code_on_used_function() {
+        let src = "\
+#[allow(dead_code)]
+pub fn helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("src/lib.rs", src)]);
+        // Simulate another file importing `helper`.
+        let map = map_with_import("src/consumer.rs", &["helper"]);
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            result.fixes.iter().any(
+                |f| f.category == SlopCategory::StaleSuppression && f.reason.contains("helper")
+            ),
+            "should flag stale allow(dead_code) on an imported symbol; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn ignores_allow_dead_code_on_genuinely_dead_symbol() {
+        let src = "\
+#[allow(dead_code)]
+pub fn helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("src/lib.rs", src)]);
+        // Another file imports a DIFFERENT name.
+        let map = map_with_import("src/consumer.rs", &["other_name"]);
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::StaleSuppression),
+            "should NOT flag allow(dead_code) when symbol truly unused; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn ignores_allow_dead_code_when_symbol_graph_absent() {
+        // Conservative: if map has no symbols section, we can't tell
+        // used from unused, so emit nothing rather than risk false
+        // positives.
+        let src = "\
+#[allow(dead_code)]
+pub fn helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("src/lib.rs", src)]);
+        let result = slop_fixes(dir.path(), &empty_map());
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::StaleSuppression),
+            "should not flag without symbol graph; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn ignores_non_suppression_allow_attributes() {
+        // `#[allow(non_snake_case)]` is a style lint, not a usage
+        // suppression. Don't touch it even if the symbol is imported.
+        let src = "\
+#[allow(non_snake_case)]
+pub fn Helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("src/lib.rs", src)]);
+        let map = map_with_import("src/consumer.rs", &["Helper"]);
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::StaleSuppression),
+            "should not flag allow(non_snake_case); got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn skips_stale_suppression_in_test_files() {
+        // `tests/foo.rs` and `src/*test*.rs` routinely have dead_code
+        // helpers. Skip them entirely.
+        let src = "\
+#[allow(dead_code)]
+pub fn helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("tests/fixture.rs", src)]);
+        let map = map_with_import("src/consumer.rs", &["helper"]);
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::StaleSuppression),
+            "should skip test files; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn ignores_inner_allow_attribute() {
+        // `#![allow(dead_code)]` is module-scoped; removing it would
+        // change the silence shape across the whole file. Leave it.
+        let src = "\
+#![allow(dead_code)]
+
+pub fn helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("src/lib.rs", src)]);
+        let map = map_with_import("src/consumer.rs", &["helper"]);
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::StaleSuppression),
+            "should not flag inner attribute; got {:?}",
+            result.fixes
         );
     }
 }

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -3236,13 +3236,13 @@ fn commented_out_code(
 // Algorithm:
 //
 // 1. Build a `used_names` set from the map: every entry in every
-//    file's `imports[].names`. Also mirror into a lowercased set for
-//    case-insensitive probes (JS/TS cross-language edges).
-// 2. For each `.rs` file, run a tree-sitter query for attribute items
-//    whose content starts with `allow(...)`. Accept the attribute
-//    only when its argument list contains one of: `dead_code`,
-//    `unused`, `unused_imports`, `unused_variables`,
-//    `unused_assignments`, `unused_must_use`.
+//    file's `imports[].names` (exact-match; Rust identifiers are
+//    case-sensitive).
+// 2. For each `.rs` file, run a tree-sitter query for `attribute_item`
+//    nodes. Accept attributes whose top-level identifier is `allow`
+//    (not nested inside e.g. `cfg_attr(...)`) and whose argument list
+//    contains one of: `dead_code`, `unused`, `unused_imports`,
+//    `unused_variables`, `unused_assignments`, `unused_must_use`.
 // 3. For each matched attribute, find the following sibling item
 //    node (fn / struct / enum / mod / const / static / trait / impl)
 //    and its identifier.
@@ -3281,35 +3281,84 @@ fn collect_used_names(map: &RepoIntelData) -> HashSet<String> {
     used
 }
 
-/// Parse the argument list of an `allow(...)` attribute. Returns the
-/// set of lint names mentioned. The tree-sitter node for the
-/// attribute is `attribute_item` with child `attribute` which in
-/// turn contains a `token_tree` of identifier tokens separated by
-/// commas. We walk the tree and collect every identifier.
+/// Parse an `#[allow(...)]` attribute via AST structure, not text
+/// scanning. Returns the list of lint names only when the attribute's
+/// top-level identifier is literally `allow` (not `cfg_attr`, not
+/// `deny`, not `warn`). This correctly skips cases like
+/// `#[cfg_attr(feature = "x", allow(dead_code))]` where `allow`
+/// appears only as a nested identifier.
+///
+/// Shape in tree-sitter-rust:
+///
+///   (attribute_item
+///     (attribute
+///       (identifier)       ; "allow" at top level
+///       arguments: (token_tree "(" (identifier)+ ")")))
+///
+/// Returns `Vec::new()` for inner attributes (`#![allow(...)]`) —
+/// those are module-scoped; removing them would change the silence
+/// shape file-wide and that's not a safe mechanical edit.
 fn extract_allow_lints(attribute_node: &tree_sitter::Node, source: &[u8]) -> Vec<String> {
-    let text = match attribute_node.utf8_text(source) {
-        Ok(t) => t,
-        Err(_) => return Vec::new(),
-    };
-    // Tolerate `#[allow(...)]` and `#![allow(...)]`. We only act on
-    // outer (#[...]) attributes; inner (#![...]) are module-scoped
-    // and removing them would change the module-wide silence shape.
-    if text.starts_with("#![") {
+    // Inner attributes (#![...]) carry an `inner` marker child or
+    // start their text with "#!["; either check works.
+    if attribute_node
+        .utf8_text(source)
+        .map(|t| t.starts_with("#!["))
+        .unwrap_or(false)
+    {
         return Vec::new();
     }
-    let Some(open) = text.find("allow(") else {
+    // Find the child `attribute` node.
+    let mut attr_inner = None;
+    let mut c = attribute_node.walk();
+    for child in attribute_node.named_children(&mut c) {
+        if child.kind() == "attribute" {
+            attr_inner = Some(child);
+            break;
+        }
+    }
+    let Some(attr_inner) = attr_inner else {
         return Vec::new();
     };
-    let rest = &text[open + "allow(".len()..];
-    let Some(close) = rest.find(')') else {
+    // The attribute's first named child is the top-level identifier
+    // (e.g. `allow`, `cfg_attr`, `derive`). Must be exactly `allow`.
+    let Some(ident) = attr_inner.named_child(0) else {
         return Vec::new();
     };
-    rest[..close]
-        .split(',')
-        .map(|s| s.trim().trim_start_matches("clippy::"))
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-        .collect()
+    if ident.kind() != "identifier" {
+        return Vec::new();
+    }
+    let top_name = ident.utf8_text(source).unwrap_or("");
+    if top_name != "allow" {
+        return Vec::new();
+    }
+    // Collect identifiers from the `token_tree` / `arguments`. The
+    // argument list holds identifier tokens (dead_code, unused, ...),
+    // possibly scoped like `clippy::needless_return`.
+    let mut out: Vec<String> = Vec::new();
+    let mut walker = attr_inner.walk();
+    for child in attr_inner.named_children(&mut walker) {
+        if child.kind() != "token_tree" {
+            continue;
+        }
+        // Walk raw characters of the token-tree text: tree-sitter
+        // tokenises the inside as a flat sequence so simple
+        // comma-split is fine here, but we strip clippy:: scope
+        // prefixes so `clippy::needless_return` becomes `needless_return`.
+        let tt_text = child.utf8_text(source).unwrap_or("");
+        // Remove the outer parentheses.
+        let inner = tt_text
+            .strip_prefix('(')
+            .and_then(|s| s.strip_suffix(')'))
+            .unwrap_or(tt_text);
+        for raw in inner.split(',') {
+            let name = raw.trim().trim_start_matches("clippy::");
+            if !name.is_empty() {
+                out.push(name.to_string());
+            }
+        }
+    }
+    out
 }
 
 /// Find the identifier of the item an attribute is attached to. Rust
@@ -3361,6 +3410,13 @@ fn stale_suppressions_rust(repo_root: &Path, map: &RepoIntelData) -> Vec<SlopFix
     let Ok(query) = tree_sitter::Query::new(&language, query_src) else {
         return out;
     };
+    // Parser and query are both reusable across files; only the tree
+    // changes per file. Instantiating them once saves tree-sitter
+    // setup cost on large repos.
+    let mut parser = tree_sitter::Parser::new();
+    if parser.set_language(&language).is_err() {
+        return out;
+    }
 
     for path in walk_repo_files(repo_root) {
         if path.extension().and_then(|e| e.to_str()) != Some("rs") {
@@ -3378,10 +3434,6 @@ fn stale_suppressions_rust(repo_root: &Path, map: &RepoIntelData) -> Vec<SlopFix
             Ok(c) => c,
             Err(_) => continue,
         };
-        let mut parser = tree_sitter::Parser::new();
-        if parser.set_language(&language).is_err() {
-            continue;
-        }
         let Some(tree) = parser.parse(&content, None) else {
             continue;
         };
@@ -5040,6 +5092,29 @@ pub fn helper(x: u32) -> u32 { x + 1 }
                 .iter()
                 .any(|f| f.category == SlopCategory::StaleSuppression),
             "should skip test files; got {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn ignores_cfg_attr_nested_allow() {
+        // `#[cfg_attr(feature = "x", allow(dead_code))]` mentions
+        // `allow` only nested inside cfg_attr. It is NOT a top-level
+        // `#[allow(...)]` and must not be flagged even when the
+        // decorated symbol is imported.
+        let src = "\
+#[cfg_attr(feature = \"x\", allow(dead_code))]
+pub fn helper(x: u32) -> u32 { x + 1 }
+";
+        let dir = make_repo(&[("src/lib.rs", src)]);
+        let map = map_with_import("src/consumer.rs", &["helper"]);
+        let result = slop_fixes(dir.path(), &map);
+        assert!(
+            !result
+                .fixes
+                .iter()
+                .any(|f| f.category == SlopCategory::StaleSuppression),
+            "should not flag nested allow inside cfg_attr; got {:?}",
             result.fixes
         );
     }

--- a/crates/analyzer-graph/src/slop_targets.rs
+++ b/crates/analyzer-graph/src/slop_targets.rs
@@ -117,6 +117,21 @@ pub fn slop_targets(
     SlopTargetsResult { targets: all }
 }
 
+/// Keep only targets that touch any path for which `predicate` returns
+/// true. For a `File` target the path is the target's own file; for an
+/// `Area` target at least one of its paths must match. Used by the CLI
+/// `--files` filter so consumers can scope results to a PR diff without
+/// doing a JS-side intersection pass.
+pub fn retain_targets_touching<F>(result: &mut SlopTargetsResult, predicate: F)
+where
+    F: Fn(&str) -> bool,
+{
+    result.targets.retain(|t| match t {
+        SlopTarget::File { path, .. } => predicate(path),
+        SlopTarget::Area { paths, .. } => paths.iter().any(|p| predicate(p)),
+    });
+}
+
 // ── Sonnet tier (file-level scoring) ─────────────────────────────
 
 fn sonnet_file_targets(map: &RepoIntelData, top: usize) -> Vec<SlopTarget> {


### PR DESCRIPTION
Two v0.7 precision features: the `--files` server-side filter on slop-fixes/entry-points/slop-targets (removes JS-side intersection in consumer plugins), and Tier 2 #7 stale-suppression detector for Rust `#[allow(dead_code)]` on symbols that are actually imported elsewhere.

## --files filter

All three queries now accept `--files a,b,c` with normalized path matching (backslashes, leading `./`, trailing slash all handled). Matches the diff-risk pattern. `slop-fixes` also regenerates its `by_file` grouping after filtering so it stays in sync.

New: `SlopAction::path()` accessor; `slop_targets::retain_targets_touching` helper (handles both File and Area variants).

## Stale-suppression detector (Rust-only)

Flags `#[allow(dead_code)]` / `#[allow(unused)]` on symbols the import graph proves are used. Confidence 0.90. Tree-sitter query for `attribute_item`, walks forward siblings to find the decorated item, checks its identifier against the used-names set built from every file's `imports[].names`.

Guards:
- Skips `#![allow(...)]` inner attributes (module-scoped)
- Skips non-suppression allow variants (e.g. `non_snake_case`)
- Skips when map has no symbols (conservative)
- Skips test files (dead_code is expected there)

## Validation

137 tests pass (6 new for stale-suppression, covering detect-hit / genuinely-dead / missing-map / non-suppression / test-file-skip / inner-attribute-skip). Clippy clean. `--files` verified e2e on agnix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new filtering paths to CLI query outputs and introduces a new Rust tree-sitter-based detector that could change `slop-fixes` results and produce false positives if the symbol graph is incomplete.
> 
> **Overview**
> Adds a `--files` option to `repo-intel query entry-points`, `slop-fixes`, and `slop-targets` to server-side filter results by a normalized set of repo-relative paths (handling `./` prefixes and Windows separators), including regenerating `slop-fixes` `by_file` after filtering.
> 
> Extends slop analysis with a new Rust-only `StaleSuppression` category that detects `#[allow(dead_code|unused…)]` attributes on items that are proven used via the import graph, emitting `DeleteLines` fixes; this includes new helpers (`SlopAction::path()`, `retain_targets_touching`) and targeted unit tests for the detector’s guardrails (skip inner attributes, tests, non-suppression allows, and missing symbol data).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd81d35c24e8b61baa8a23616fd0247d237a19b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->