### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-25
+
+### Added
+
+- **`passthrough-wrapper` detector** (#31) - new `SlopCategory::PassthroughWrapper`, confidence 0.85. Detects functions whose entire body is a single call to another function with identical args, across Rust, TypeScript/JavaScript, Python, Go, and Java. AST-based: uses tree-sitter `type_parameters` field for generic detection, `trait` field for Rust trait-impl detection, and a captured-receiver comparison for Go method self-delegation.
+- **`always-true-condition` detector** (#32) - new `SlopCategory::AlwaysTrueCondition`, confidence 0.92. Flags tautological checks (`if x == x`, `if x === x`) and contradictions (`x && !x`, `x == null && x != null`, `x === null && x !== null`) across all 5 languages. Paren-aware via `split_top_level_op`.
+- **`commented-out-code` detector** (#33) - new `SlopCategory::CommentedOutCode`, confidence 0.85. Detects comment blocks whose content re-parses as valid code in the surrounding language. Tree-sitter re-parse with zero-ERROR + substantive-node requirement. Handles leading-star block-comment layout, preserves Python indentation, rejects `///` / `//!` / `/**` / `/*!` doc comments. Per-line marker check skips TODO / FIXME / NOTE / HACK / XXX / WARNING / SAFETY / agentsys-ignore / SPDX-License.
+- **`stale-suppression` detector (Rust only)** (#34) - new `SlopCategory::StaleSuppression`, confidence 0.90. Flags `#[allow(dead_code)]` / `#[allow(unused)]` on symbols the import graph proves are used. `UsedSymbols::modules_per_name` segment-matches against the target file's path to guard against name-collision false positives. Only emits when EVERY lint is a suppression candidate (mixed-lint attributes left alone). Skips inner attributes, nested `cfg_attr(..., allow(...))`, and test files.
+- **External entry-points detection** (#29) - new `repo-intel query entry-points`: Cargo `[[bin]]` / `[[test]]` / `[[bench]]` / `[[example]]`, `main()` functions via AST, `package.json bin` scripts, framework-loaded configs (Next / Vite / Astro / Svelte / Docusaurus / Tailwind / PostCSS / Rollup / Webpack / Babel / Jest / Vitest / Playwright), and Python `__main__.py`. `.cjs` and `.mjs` variants included. Reduced orphan-export false positives from 52 to 0 on agnix.
+- **`agentsys-ignore` suppression directives** (#30) - per-fix suppression via `// agentsys-ignore[: <category>]` and `// agentsys-ignore-all`. Supports `//`, `#`, and `--` markers. 3-line lookback + same-line inline trailing. File-deletion fixes suppressible by a header directive in the first 5 lines.
+- **Confidence scores per `SlopCategory`** (#32) - new `Confidence` type alias (f32). `default_confidence(category)` returns per-category defaults (0.75-0.97). Serde default keeps older JSON artifacts compatible.
+- **`group_by_file` output** (#32) - `SlopFixesResult` now carries a `by_file: Vec<FileFixes>` alongside flat `fixes`. Deterministic alphabetic sort.
+- **Word-boundary cliché matching** (#30) - `tokenize_identifier` uses case transitions and separator boundaries (camelCase / snake_case / kebab-case / PascalCase). O(N) single-pass.
+- **`--files` filter on three queries** (#34) - `slop-fixes`, `entry-points`, and `slop-targets` accept `--files a,b,c` to restrict results. Windows paths normalized. New public `SlopAction::path()` accessor + `slop_targets::retain_targets_touching` helper.
+
+### Changed
+
+- **`SlopAction::path()` signature** (#34) - now returns `&str` (total) instead of `Option<&str>`. Every variant has a path.
+- **`category_kebab` hot path** (#30) - returns `&'static str` from a match arm instead of `serde_json::to_value` per call.
+
+### Fixed
+
+- Addressed 19+ reviewer-flagged items across the 6 slop PRs: single-pass partition loops, parser hoisting, AST field checks replacing string scans, shebang handling for Hash-style comments, paren-aware operator splitting, `strip_one_paren_pair` depth handling, `CommentKind` line/block tracking, nested `cfg_attr` allow guard, name-collision guard on stale-suppression, mixed-lint all-suppression requirement.
+
 ## [0.6.0] - 2026-04-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "analyzer-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "analyzer-collectors",
  "analyzer-core",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-collectors"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-embed"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-git-map"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-graph"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "analyzer-core",
  "analyzer-embed",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-repo-map"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "analyzer-core",
  "anyhow",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "analyzer-sync-check"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "analyzer-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
Slop-precision release. Version bump 0.6.0 -> 0.7.0.

## Headline features
- **4 new SlopCategory detectors** (Rust + TS/JS + Python + Go + Java where applicable): passthrough-wrapper, always-true-condition, commented-out-code, stale-suppression (Rust-only)
- **External entry-points query** (Cargo [[bin]], main fns, framework configs, __main__.py) - eliminates orphan-export false positives (52 -> 0 on agnix)
- **agentsys-ignore directives** for per-fix suppression
- **Confidence scores** per SlopCategory (0.75-0.97)
- **group_by_file output** alongside flat fixes array
- **--files filter** on slop-fixes / entry-points / slop-targets - removes JS-side intersection in consumer plugins
- **Word-boundary cliche matching** - stops false-flagging 'Manager' inside 'ChannelManagerState'

## Scope of work
Since v0.6.0: 6 PRs (#29, #30, #31, #32, #33, #34). 19+ reviewer-flagged items fixed during iteration. All tests + clippy + cargo-deny pass.

See CHANGELOG.md [0.7.0] for the full list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR is a release bookkeeping change (version bumps and changelog updates) with no functional code modifications.
> 
> **Overview**
> Prepares the `v0.7.0` release by bumping the workspace and crate versions from `0.6.0` to `0.7.0` in `Cargo.toml`/`Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the new `0.7.0` section summarizing the newly added slop detectors, entry-point detection, suppression directives, confidence scoring, output shape changes, and related fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9d70ba8b49117881a2ecb12d25e308b5866531d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->