### PR TITLE
fix(analyzer-embed): stable cache dir + heal poisoned fastembed caches

### DIFF
--- a/crates/analyzer-embed/src/model.rs
+++ b/crates/analyzer-embed/src/model.rs
@@ -46,7 +46,6 @@ impl FastEmbedder {
     /// downloads the model files; subsequent constructions read from the
     /// fastembed cache.
     pub fn new(variant: ModelVariant) -> Result<Self> {
-        let fastembed_model = map_variant(variant);
         let cache_dir = resolve_cache_dir();
 
         if let Err(e) = std::fs::create_dir_all(&cache_dir) {
@@ -56,9 +55,9 @@ impl FastEmbedder {
             );
         }
 
-        prune_poisoned_cache(&cache_dir, model_code_for(&fastembed_model));
+        prune_poisoned_cache(&cache_dir, &model_code_for(map_variant(variant))?);
 
-        let mut opts = InitOptions::new(fastembed_model.clone()).with_show_download_progress(true);
+        let mut opts = InitOptions::new(map_variant(variant)).with_show_download_progress(true);
         opts = opts.with_cache_dir(cache_dir.clone());
 
         let model = TextEmbedding::try_new(opts).with_context(|| {
@@ -98,17 +97,22 @@ fn map_variant(v: ModelVariant) -> EmbeddingModel {
     }
 }
 
-/// HuggingFace model code for a fastembed model. This is the string
-/// fastembed uses to form the on-disk cache dir: `models--<org>--<name>`
-/// where `/` in the code becomes `--`. Hardcoding the two variants we
-/// support avoids a runtime lookup and keeps the cache layout logic
-/// independent of fastembed's private model registry.
-fn model_code_for(model: &EmbeddingModel) -> &'static str {
-    match model {
-        EmbeddingModel::BGESmallENV15Q => "Qdrant/bge-small-en-v1.5-onnx-Q",
-        EmbeddingModel::EmbeddingGemma300M => "onnx-community/embeddinggemma-300m-ONNX",
-        _ => "",
-    }
+/// HuggingFace model code for a fastembed model. Fastembed uses this to
+/// form the on-disk cache dir: `models--<org>--<name>` where `/` in the
+/// code becomes `--`.
+///
+/// We delegate to `TextEmbedding::get_model_info`, which is the stable
+/// accessor into fastembed's own model registry. This matters because
+/// `EmbeddingModel` is `#[non_exhaustive]` upstream: a hardcoded `match`
+/// with a catch-all `_ => ""` branch would silently break cache-layout
+/// logic (e.g., `prune_poisoned_cache`) if fastembed added a variant we
+/// later started using - the catch-all would return the empty string and
+/// the poisoned-cache detector would no-op. Using the upstream lookup
+/// forwards the error instead so breakage is loud.
+fn model_code_for(model: EmbeddingModel) -> Result<String> {
+    TextEmbedding::get_model_info(&model)
+        .map(|info| info.model_code.clone())
+        .with_context(|| format!("fastembed has no ModelInfo for {model:?}"))
 }
 
 /// Resolve the cache directory per the precedence documented on
@@ -221,6 +225,17 @@ mod tests {
             map_variant(ModelVariant::Big),
             EmbeddingModel::EmbeddingGemma300M
         ));
+    }
+
+    #[test]
+    fn model_code_for_supported_variants_succeeds() {
+        // Both variants we care about must resolve through fastembed's
+        // ModelInfo registry. If fastembed ever drops one of these the
+        // test fires before users hit a runtime error.
+        let small = model_code_for(map_variant(ModelVariant::Small)).unwrap();
+        assert_eq!(small, "Qdrant/bge-small-en-v1.5-onnx-Q");
+        let big = model_code_for(map_variant(ModelVariant::Big)).unwrap();
+        assert_eq!(big, "onnx-community/embeddinggemma-300m-ONNX");
     }
 
     #[test]

--- a/crates/analyzer-embed/src/model.rs
+++ b/crates/analyzer-embed/src/model.rs
@@ -58,8 +58,7 @@ impl FastEmbedder {
 
         prune_poisoned_cache(&cache_dir, model_code_for(&fastembed_model));
 
-        let mut opts =
-            InitOptions::new(fastembed_model.clone()).with_show_download_progress(true);
+        let mut opts = InitOptions::new(fastembed_model.clone()).with_show_download_progress(true);
         opts = opts.with_cache_dir(cache_dir.clone());
 
         let model = TextEmbedding::try_new(opts).with_context(|| {

--- a/crates/analyzer-embed/src/model.rs
+++ b/crates/analyzer-embed/src/model.rs
@@ -4,9 +4,31 @@
 //! download / cache. We pick from its `EmbeddingModel` enum based on
 //! [`ModelVariant`] and pass through the embed call.
 //!
-//! Model files land in fastembed's default cache (`~/.cache/fastembed/`
-//! or platform equivalent). The skill prompts the user once at install
-//! time and persists the choice; this binary just consumes that decision.
+//! # Cache location
+//!
+//! By default fastembed writes to `./.fastembed_cache` relative to the
+//! current working directory. That is wrong for us: every user repo
+//! would download its own 66 MB+ copy and pollute the user's working
+//! tree. Worse, if the process is killed mid-download fastembed's
+//! cache layout ends up half-built (`refs/main` written, `snapshots/`
+//! still empty) and subsequent runs hang inside `TextEmbedding::try_new`
+//! with no log output.
+//!
+//! We resolve a stable cache directory in this precedence:
+//!
+//! 1. `FASTEMBED_CACHE_DIR` env var if set (fastembed already respects
+//!    this; we mirror the precedence explicitly so our error messages
+//!    can name the directory).
+//! 2. `~/.agent-sh/cache/fastembed` (matches where the binary lives in
+//!    `~/.agent-sh/bin/`).
+//! 3. Fastembed's built-in default as a last resort, if no home dir can
+//!    be resolved.
+//!
+//! We also best-effort detect and remove a "poisoned" cache layout
+//! before calling into fastembed, so an interrupted first run doesn't
+//! strand the user.
+
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
@@ -24,9 +46,30 @@ impl FastEmbedder {
     /// downloads the model files; subsequent constructions read from the
     /// fastembed cache.
     pub fn new(variant: ModelVariant) -> Result<Self> {
-        let opts = InitOptions::new(map_variant(variant)).with_show_download_progress(true);
-        let model = TextEmbedding::try_new(opts)
-            .with_context(|| format!("initialize fastembed model for variant {variant:?}"))?;
+        let fastembed_model = map_variant(variant);
+        let cache_dir = resolve_cache_dir();
+
+        if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+            eprintln!(
+                "analyzer-embed: warning: could not create cache dir {}: {e}",
+                cache_dir.display()
+            );
+        }
+
+        prune_poisoned_cache(&cache_dir, model_code_for(&fastembed_model));
+
+        let mut opts =
+            InitOptions::new(fastembed_model.clone()).with_show_download_progress(true);
+        opts = opts.with_cache_dir(cache_dir.clone());
+
+        let model = TextEmbedding::try_new(opts).with_context(|| {
+            format!(
+                "initialize fastembed model for variant {variant:?} (cache dir: {}). \
+                 If the download appears to hang, check network/proxy settings or set \
+                 FASTEMBED_CACHE_DIR to an alternative writable path.",
+                cache_dir.display()
+            )
+        })?;
         Ok(Self { variant, model })
     }
 }
@@ -56,9 +99,115 @@ fn map_variant(v: ModelVariant) -> EmbeddingModel {
     }
 }
 
+/// HuggingFace model code for a fastembed model. This is the string
+/// fastembed uses to form the on-disk cache dir: `models--<org>--<name>`
+/// where `/` in the code becomes `--`. Hardcoding the two variants we
+/// support avoids a runtime lookup and keeps the cache layout logic
+/// independent of fastembed's private model registry.
+fn model_code_for(model: &EmbeddingModel) -> &'static str {
+    match model {
+        EmbeddingModel::BGESmallENV15Q => "Qdrant/bge-small-en-v1.5-onnx-Q",
+        EmbeddingModel::EmbeddingGemma300M => "onnx-community/embeddinggemma-300m-ONNX",
+        _ => "",
+    }
+}
+
+/// Resolve the cache directory per the precedence documented on
+/// [`FastEmbedder`]: env var, then `~/.agent-sh/cache/fastembed`, then
+/// fastembed's default.
+fn resolve_cache_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("FASTEMBED_CACHE_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
+        }
+    }
+    if let Some(home) = home_dir() {
+        return home.join(".agent-sh").join("cache").join("fastembed");
+    }
+    // Last resort: fastembed's built-in default, `./.fastembed_cache`
+    // relative to CWD. Better than nothing, but prints a warning so
+    // users know their cache is ephemeral.
+    eprintln!(
+        "analyzer-embed: warning: could not resolve a home directory; \
+         falling back to CWD-relative .fastembed_cache. Set \
+         FASTEMBED_CACHE_DIR to control the cache location."
+    );
+    PathBuf::from(".fastembed_cache")
+}
+
+fn home_dir() -> Option<PathBuf> {
+    // Platform-appropriate home lookup without pulling in the `dirs`
+    // crate. USERPROFILE is Windows; HOME covers macOS/Linux.
+    if let Ok(p) = std::env::var("USERPROFILE") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    if let Ok(p) = std::env::var("HOME") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    None
+}
+
+/// Best-effort detection of a half-built model cache. Fastembed creates
+/// `models--<org>--<name>/refs/main` early in the download; if the
+/// process is killed before it finalizes, `snapshots/` stays empty and
+/// the next run hangs. Remove such a directory so fastembed re-downloads
+/// cleanly.
+///
+/// This is best-effort: any IO error is logged to stderr and swallowed.
+fn prune_poisoned_cache(cache_dir: &Path, model_code: &str) {
+    if model_code.is_empty() {
+        return;
+    }
+    let dir_name = format!("models--{}", model_code.replace('/', "--"));
+    let model_dir = cache_dir.join(&dir_name);
+    if !model_dir.is_dir() {
+        return;
+    }
+    let refs_main = model_dir.join("refs").join("main");
+    let snapshots = model_dir.join("snapshots");
+    let has_refs = refs_main.is_file();
+    let has_snapshot = snapshots
+        .read_dir()
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false);
+
+    if has_refs && !has_snapshot {
+        eprintln!(
+            "analyzer-embed: detected poisoned fastembed cache at {}; \
+             removing so the model can be re-downloaded",
+            model_dir.display()
+        );
+        if let Err(e) = std::fs::remove_dir_all(&model_dir) {
+            eprintln!(
+                "analyzer-embed: warning: failed to remove poisoned cache {}: {e}",
+                model_dir.display()
+            );
+        }
+        // Also drop any stale `.lock` file next to it, which fastembed
+        // uses to serialize downloads. A leftover lock after a crash
+        // will not block us (fastembed uses advisory locks) but it is
+        // visual noise.
+        let lock = cache_dir.join(format!("{dir_name}.lock"));
+        if lock.exists() {
+            let _ = std::fs::remove_file(lock);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    // Tests that manipulate process-wide env vars must not run
+    // concurrently. Rust's default test harness runs tests in parallel
+    // per-binary, so we serialize with a mutex.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn variant_maps_to_expected_fastembed_model() {
@@ -75,9 +224,118 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn prune_removes_poisoned_layout() {
+        let tmp = tempdir().unwrap();
+        let code = "Qdrant/bge-small-en-v1.5-onnx-Q";
+        let dir_name = "models--Qdrant--bge-small-en-v1.5-onnx-Q";
+        let model_dir = tmp.path().join(dir_name);
+        std::fs::create_dir_all(model_dir.join("refs")).unwrap();
+        std::fs::create_dir_all(model_dir.join("snapshots")).unwrap();
+        std::fs::create_dir_all(model_dir.join("blobs")).unwrap();
+        std::fs::write(model_dir.join("refs").join("main"), b"deadbeef").unwrap();
+        // Drop a fake blob to mimic a partial download.
+        std::fs::write(model_dir.join("blobs").join("abc"), b"x").unwrap();
+
+        prune_poisoned_cache(tmp.path(), code);
+
+        assert!(
+            !model_dir.exists(),
+            "poisoned model dir should have been removed"
+        );
+    }
+
+    #[test]
+    fn prune_leaves_healthy_layout_alone() {
+        let tmp = tempdir().unwrap();
+        let code = "Qdrant/bge-small-en-v1.5-onnx-Q";
+        let dir_name = "models--Qdrant--bge-small-en-v1.5-onnx-Q";
+        let model_dir = tmp.path().join(dir_name);
+        let snapshot = model_dir.join("snapshots").join("deadbeef");
+        std::fs::create_dir_all(&snapshot).unwrap();
+        std::fs::create_dir_all(model_dir.join("refs")).unwrap();
+        std::fs::write(model_dir.join("refs").join("main"), b"deadbeef").unwrap();
+        std::fs::write(snapshot.join("model.onnx"), b"fake-onnx").unwrap();
+
+        prune_poisoned_cache(tmp.path(), code);
+
+        assert!(model_dir.exists(), "healthy cache should be preserved");
+        assert!(snapshot.join("model.onnx").exists());
+    }
+
+    #[test]
+    fn prune_is_noop_when_model_dir_missing() {
+        let tmp = tempdir().unwrap();
+        // Should not panic, should not create anything.
+        prune_poisoned_cache(tmp.path(), "Qdrant/bge-small-en-v1.5-onnx-Q");
+        assert!(tmp.path().read_dir().unwrap().next().is_none());
+    }
+
+    #[test]
+    fn resolve_cache_dir_prefers_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempdir().unwrap();
+        let expected = tmp.path().join("custom-cache");
+        // SAFETY: guarded by ENV_LOCK; std::env::set_var is unsafe in
+        // edition 2024 but fine here because tests in this binary are
+        // serialized via the mutex.
+        unsafe {
+            std::env::set_var("FASTEMBED_CACHE_DIR", &expected);
+        }
+        let got = resolve_cache_dir();
+        unsafe {
+            std::env::remove_var("FASTEMBED_CACHE_DIR");
+        }
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn resolve_cache_dir_falls_back_to_home() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempdir().unwrap();
+        let fake_home = tmp.path().to_path_buf();
+
+        // Save + clear env we care about.
+        let saved_fec = std::env::var_os("FASTEMBED_CACHE_DIR");
+        let saved_home = std::env::var_os("HOME");
+        let saved_userprofile = std::env::var_os("USERPROFILE");
+
+        unsafe {
+            std::env::remove_var("FASTEMBED_CACHE_DIR");
+            // Set both so the lookup succeeds on all platforms.
+            std::env::set_var("HOME", &fake_home);
+            std::env::set_var("USERPROFILE", &fake_home);
+        }
+
+        let got = resolve_cache_dir();
+
+        unsafe {
+            match saved_fec {
+                Some(v) => std::env::set_var("FASTEMBED_CACHE_DIR", v),
+                None => std::env::remove_var("FASTEMBED_CACHE_DIR"),
+            }
+            match saved_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match saved_userprofile {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+
+        assert_eq!(
+            got,
+            fake_home.join(".agent-sh").join("cache").join("fastembed")
+        );
+    }
+
     // Integration tests that actually download + run the model live in
     // tests/integration_embed.rs, gated behind --ignored so CI doesn't
     // pull ~225 MB of model files on every PR. Run locally with:
     //
     //   cargo test -p analyzer-embed -- --ignored
+    //
+    // Those tests now write to `~/.agent-sh/cache/fastembed` (or
+    // `$FASTEMBED_CACHE_DIR` if set) instead of `./.fastembed_cache`.
 }


### PR DESCRIPTION
## Summary

The embedder was silently hanging on first use because:

1. `FastEmbedder::new` called `InitOptions::new(...).with_show_download_progress(true)` without `.with_cache_dir(...)` — fastembed defaults to `./.fastembed_cache` (relative to CWD). Every user repo got its own 66 MB download, polluted the working tree, and a killed process (Ctrl+C, timeout) left a half-written cache.
2. On the next run, fastembed sees `refs/main` pointing at a snapshot that doesn't exist yet → hangs re-resolving. No error surfaced to the user.

## Fix

- Resolve a stable cache dir with precedence: `FASTEMBED_CACHE_DIR` env → `~/.agent-sh/cache/fastembed` → fastembed default
- Create the dir before `TextEmbedding::try_new`
- Validate the cache on init; if a model repo has `refs/main` but empty `snapshots/`, treat as poisoned and remove before retry
- Wrap `try_new` with clearer error context (cache path, variant, `FASTEMBED_CACHE_DIR` hint)

## Test plan

- `cargo test -p analyzer-embed` — 33 pass (5 new)
- `cargo check --release -p analyzer-embed` — clean
- Integration test behind `--ignored` still works (documented the new cache location in a comment)

## Related

Root-cause of "embedder didn't download" reports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model initialization to force a new cache location and to delete suspected corrupted caches; mistakes here could trigger unnecessary re-downloads or remove user cache data, but impact is limited to local filesystem state.
> 
> **Overview**
> `FastEmbedder::new` now resolves and sets an explicit fastembed cache directory (preferring `FASTEMBED_CACHE_DIR`, else `~/.agent-sh/cache/fastembed`, else CWD fallback) and creates it before initializing the model.
> 
> Adds best-effort detection/removal of half-built model cache directories (presence of `refs/main` with empty `snapshots/`) plus stale lock cleanup to avoid hangs on subsequent runs, and improves error context to include cache path and troubleshooting guidance.
> 
> Introduces unit tests for cache-dir resolution and poisoned-cache pruning, serializing env-var tests with a mutex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a51b8fd2b6a1d76ba48c1abe29d34ba9893b66d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->