### PR TITLE
fix(security): sidecar OOM caps, secret-file exclusion, SLSA attestations, cargo-deny

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 permissions:
   contents: write
+  # Required for actions/attest-build-provenance to sign attestations
+  # via the workflow's OIDC identity and write them to the release.
+  id-token: write
+  attestations: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -109,6 +113,29 @@ jobs:
           cd ../../..
           (Get-FileHash agent-analyzer-${{ matrix.target }}.zip -Algorithm SHA256).Hash.ToLower() + "  agent-analyzer-${{ matrix.target }}.zip" | Out-File -Encoding ASCII agent-analyzer-${{ matrix.target }}.zip.sha256
           (Get-FileHash agent-analyzer-embed-${{ matrix.target }}.zip -Algorithm SHA256).Hash.ToLower() + "  agent-analyzer-embed-${{ matrix.target }}.zip" | Out-File -Encoding ASCII agent-analyzer-embed-${{ matrix.target }}.zip.sha256
+
+      # SLSA build-provenance attestations. These are uploaded as separate
+      # .intoto.jsonl files alongside the tarballs so downloaders *can*
+      # verify with cosign / slsa-verifier, but the agent-core downloader
+      # does not yet consume them - this is defense-in-depth at publish
+      # time, client-side verification is a follow-up.
+      - name: Attest release artifacts (Unix)
+        if: runner.os != 'Windows'
+        # Pin to SHA to prevent a malicious tag reassignment from silently
+        # replacing the attestation step. Bump via Dependabot.
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd
+        with:
+          subject-path: |
+            agent-analyzer-${{ matrix.target }}.tar.gz
+            agent-analyzer-embed-${{ matrix.target }}.tar.gz
+
+      - name: Attest release artifacts (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd
+        with:
+          subject-path: |
+            agent-analyzer-${{ matrix.target }}.zip
+            agent-analyzer-embed-${{ matrix.target }}.zip
 
       - name: Upload agent-analyzer artifact
         uses: actions/upload-artifact@v4

--- a/crates/analyzer-core/src/lib.rs
+++ b/crates/analyzer-core/src/lib.rs
@@ -4,6 +4,8 @@ pub mod bot_detect;
 pub mod bug_fix_detect;
 pub mod generated_detect;
 pub mod git;
+pub mod limits;
 pub mod output;
+pub mod secrets;
 pub mod types;
 pub mod walk;

--- a/crates/analyzer-core/src/limits.rs
+++ b/crates/analyzer-core/src/limits.rs
@@ -1,0 +1,30 @@
+//! Shared size/length caps for defense-in-depth bounds checking.
+//!
+//! These constants are centralized so analyzer-embed and analyzer-graph
+//! (and future crates) agree on the thresholds. The rationale for each
+//! cap is inline below.
+
+/// Maximum size, in bytes, of a single file we are willing to read into
+/// memory during a repo walk.
+///
+/// The slop/embed analyzers read the whole file to parse with tree-sitter
+/// or hash for embeddings, so unbounded sizes are a DoS vector. 5 MiB
+/// comfortably covers the legitimate long tail of source files; generated
+/// or vendored files past this are almost always noise for our analyses.
+pub const MAX_WALK_FILE_SIZE: u64 = 5 * 1024 * 1024;
+
+/// Cap on symbol/name strings stored in the embed sidecar. Names here
+/// are function / type identifiers, not paths.
+///
+/// 1 KiB is already generous; real identifiers are far shorter. Used to
+/// bound memory when reading attacker-controlled length-prefixed strings
+/// out of the sidecar binary format.
+pub const MAX_NAME_LEN: usize = 1024;
+
+/// Cap on filesystem path strings stored in the embed sidecar.
+///
+/// Paths can be genuinely long in deeply nested monorepos (workspace
+/// packages, node_modules-style layouts), so 1 KiB (the `MAX_NAME_LEN`
+/// used for identifiers) is too tight. 4096 matches PATH_MAX on Linux
+/// and is far larger than any real code path we would embed.
+pub const MAX_PATH_LEN: usize = 4096;

--- a/crates/analyzer-core/src/secrets.rs
+++ b/crates/analyzer-core/src/secrets.rs
@@ -1,0 +1,115 @@
+//! Shared deny-list for known-secret file patterns.
+//!
+//! The repo walkers in analyzer-embed (embedding/indexing) and
+//! analyzer-graph (slop detection) both want to skip files that are
+//! almost certainly secrets to avoid surfacing them in indexes, logs, or
+//! diagnostics. This module is the single source of truth for the
+//! patterns they match on.
+//!
+//! This is defense-in-depth on top of `ignore::WalkBuilder::hidden(true)`
+//! and `.standard_filters(true)`. The walker already excludes dotfiles
+//! on Unix-like platforms, but:
+//!
+//! - `.hidden` semantics differ by platform.
+//! - Non-hidden variants like `id_rsa`, `server.pem`, or anything under
+//!   `.ssh/` / `.aws/` can still slip through.
+//!
+//! Keep this list conservative: false positives only cost one skipped
+//! file; false negatives can leak credentials into an index or report.
+
+use std::path::Path;
+
+/// Returns `true` if the path looks like a file or directory we should
+/// refuse to read during repo analysis because it likely contains
+/// credentials.
+pub fn is_secret_like(path: &Path) -> bool {
+    let name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(n) => n,
+        None => return false,
+    };
+
+    // Dotfile names we care about even if the walker misses them (e.g.
+    // on platforms where `.hidden` has different semantics).
+    if matches!(name, ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd") {
+        return true;
+    }
+    if name.starts_with(".env.") {
+        return true;
+    }
+
+    // SSH private-key filename conventions.
+    if name.starts_with("id_rsa")
+        || name.starts_with("id_dsa")
+        || name.starts_with("id_ecdsa")
+        || name.starts_with("id_ed25519")
+    {
+        return true;
+    }
+
+    // File extensions that are almost always cryptographic material.
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    if let Some(e) = ext.as_deref()
+        && matches!(
+            e,
+            "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore"
+        )
+    {
+        return true;
+    }
+
+    // Secret-bearing directories: anywhere in the path.
+    for comp in path.components() {
+        if let Some(c) = comp.as_os_str().to_str()
+            && matches!(
+                c,
+                ".git" | ".ssh" | ".gnupg" | ".aws" | ".gcloud" | ".azure"
+            )
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn dotenv_variants_are_secret_like() {
+        assert!(is_secret_like(&PathBuf::from(".env")));
+        assert!(is_secret_like(&PathBuf::from(".env.local")));
+        assert!(is_secret_like(&PathBuf::from(".env.production")));
+    }
+
+    #[test]
+    fn ssh_private_keys_are_secret_like() {
+        assert!(is_secret_like(&PathBuf::from("id_rsa")));
+        assert!(is_secret_like(&PathBuf::from("id_ed25519")));
+        assert!(is_secret_like(&PathBuf::from("id_rsa.pub"))); // matches prefix rule
+    }
+
+    #[test]
+    fn pem_extensions_are_secret_like() {
+        assert!(is_secret_like(&PathBuf::from("server.pem")));
+        assert!(is_secret_like(&PathBuf::from("keystore.jks")));
+        assert!(is_secret_like(&PathBuf::from("cert.CRT"))); // case-insensitive
+    }
+
+    #[test]
+    fn secret_directories_are_matched_anywhere() {
+        assert!(is_secret_like(&PathBuf::from("home/me/.ssh/config")));
+        assert!(is_secret_like(&PathBuf::from("project/.aws/credentials")));
+    }
+
+    #[test]
+    fn ordinary_files_are_not_secret_like() {
+        assert!(!is_secret_like(&PathBuf::from("README.md")));
+        assert!(!is_secret_like(&PathBuf::from("src/main.rs")));
+        assert!(!is_secret_like(&PathBuf::from("config.toml")));
+    }
+}

--- a/crates/analyzer-embed/src/scan.rs
+++ b/crates/analyzer-embed/src/scan.rs
@@ -13,6 +13,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use analyzer_core::limits::MAX_WALK_FILE_SIZE;
+use analyzer_core::secrets::is_secret_like;
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
 use ignore::WalkBuilder;
@@ -217,18 +219,12 @@ fn load_existing_hashes(
 }
 
 /// Maximum size of any single file the embed/slop walkers will read.
-/// Generated or vendored source files can easily balloon past typical
-/// source sizes; reading a multi-hundred-MiB file into memory to hash and
-/// chunk it is almost never what we want. 5 MiB comfortably covers the
-/// legitimate long tail.
-pub(crate) const MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
-
 fn walk_repo(repo: &Path, max_files: usize) -> Result<Vec<(PathBuf, String)>> {
     let mut out = Vec::new();
     for entry in WalkBuilder::new(repo)
         .standard_filters(true)
         .hidden(true)
-        .max_filesize(Some(MAX_FILE_BYTES))
+        .max_filesize(Some(MAX_WALK_FILE_SIZE))
         .build()
     {
         let entry = match entry {
@@ -256,58 +252,6 @@ fn walk_repo(repo: &Path, max_files: usize) -> Result<Vec<(PathBuf, String)>> {
         }
     }
     Ok(out)
-}
-
-/// Explicit deny-list for known-secret patterns. `.hidden(true)` on the
-/// walker already excludes dot-prefixed files/dirs on Unix (and any path
-/// containing a dot-prefixed component); this is a belt-and-suspenders
-/// check that also catches non-hidden variants like `id_rsa` or `*.pem`
-/// that a user might have committed by accident.
-fn is_secret_like(path: &Path) -> bool {
-    let name = match path.file_name().and_then(|n| n.to_str()) {
-        Some(n) => n,
-        None => return false,
-    };
-    // Dotfile names we care about even if the walker misses them (e.g.
-    // on platforms where `.hidden` has different semantics).
-    let dotfile_exact = matches!(name, ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd");
-    if dotfile_exact {
-        return true;
-    }
-    if name.starts_with(".env.") {
-        return true;
-    }
-    if name.starts_with("id_rsa")
-        || name.starts_with("id_dsa")
-        || name.starts_with("id_ecdsa")
-        || name.starts_with("id_ed25519")
-    {
-        return true;
-    }
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.to_ascii_lowercase());
-    if let Some(e) = ext.as_deref()
-        && matches!(
-            e,
-            "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore"
-        )
-    {
-        return true;
-    }
-    // Secret-bearing directories: anywhere in the path.
-    for comp in path.components() {
-        if let Some(c) = comp.as_os_str().to_str()
-            && matches!(
-                c,
-                ".git" | ".ssh" | ".gnupg" | ".aws" | ".gcloud" | ".azure"
-            )
-        {
-            return true;
-        }
-    }
-    false
 }
 
 fn is_eligible(path: &Path) -> bool {

--- a/crates/analyzer-embed/src/scan.rs
+++ b/crates/analyzer-embed/src/scan.rs
@@ -220,7 +220,7 @@ fn walk_repo(repo: &Path, max_files: usize) -> Result<Vec<(PathBuf, String)>> {
     let mut out = Vec::new();
     for entry in WalkBuilder::new(repo)
         .standard_filters(true)
-        .hidden(false)
+        .hidden(true)
         .build()
     {
         let entry = match entry {
@@ -234,6 +234,9 @@ fn walk_repo(repo: &Path, max_files: usize) -> Result<Vec<(PathBuf, String)>> {
         if !is_eligible(&path) {
             continue;
         }
+        if is_secret_like(&path) {
+            continue;
+        }
         let content = match fs::read(&path) {
             Ok(c) => c,
             Err(_) => continue,
@@ -245,6 +248,58 @@ fn walk_repo(repo: &Path, max_files: usize) -> Result<Vec<(PathBuf, String)>> {
         }
     }
     Ok(out)
+}
+
+/// Explicit deny-list for known-secret patterns. `.hidden(true)` on the
+/// walker already excludes dot-prefixed files/dirs on Unix (and any path
+/// containing a dot-prefixed component); this is a belt-and-suspenders
+/// check that also catches non-hidden variants like `id_rsa` or `*.pem`
+/// that a user might have committed by accident.
+fn is_secret_like(path: &Path) -> bool {
+    let name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(n) => n,
+        None => return false,
+    };
+    // Dotfile names we care about even if the walker misses them (e.g.
+    // on platforms where `.hidden` has different semantics).
+    let dotfile_exact = matches!(
+        name,
+        ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd"
+    );
+    if dotfile_exact {
+        return true;
+    }
+    if name.starts_with(".env.") {
+        return true;
+    }
+    if name.starts_with("id_rsa")
+        || name.starts_with("id_dsa")
+        || name.starts_with("id_ecdsa")
+        || name.starts_with("id_ed25519")
+    {
+        return true;
+    }
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    if let Some(e) = ext.as_deref()
+        && matches!(e, "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore")
+    {
+        return true;
+    }
+    // Secret-bearing directories: anywhere in the path.
+    for comp in path.components() {
+        if let Some(c) = comp.as_os_str().to_str()
+            && matches!(
+                c,
+                ".git" | ".ssh" | ".gnupg" | ".aws" | ".gcloud" | ".azure"
+            )
+        {
+            return true;
+        }
+    }
+    false
 }
 
 fn is_eligible(path: &Path) -> bool {
@@ -442,6 +497,35 @@ mod tests {
         };
         let doc = run_scan(&mut embedder, &opts).unwrap();
         assert!(doc.files.contains_key("nested/inner/a.rs"));
+    }
+
+    #[test]
+    fn walk_excludes_dotfiles_and_secret_patterns() {
+        let dir = make_repo(&[
+            ("src/a.rs", "fn a() {}\n"),
+            (".env", "SECRET=hunter2\n"),
+            (".git/config", "[core]\n"),
+            (".ssh/id_rsa", "-----BEGIN RSA PRIVATE KEY-----\n"),
+            ("keys/server.pem", "-----BEGIN CERTIFICATE-----\n"),
+            ("keys/server.key", "-----BEGIN PRIVATE KEY-----\n"),
+        ]);
+        let files = walk_repo(dir.path(), 100).unwrap();
+        let rels: Vec<String> = files
+            .iter()
+            .map(|(p, _)| {
+                p.strip_prefix(dir.path())
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        assert!(rels.iter().any(|p| p == "src/a.rs"), "src/a.rs missing: {rels:?}");
+        for forbidden in [".env", ".git/config", ".ssh/id_rsa", "keys/server.pem", "keys/server.key"] {
+            assert!(
+                !rels.iter().any(|p| p == forbidden),
+                "secret-like path {forbidden} should have been excluded: {rels:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/analyzer-embed/src/scan.rs
+++ b/crates/analyzer-embed/src/scan.rs
@@ -270,10 +270,7 @@ fn is_secret_like(path: &Path) -> bool {
     };
     // Dotfile names we care about even if the walker misses them (e.g.
     // on platforms where `.hidden` has different semantics).
-    let dotfile_exact = matches!(
-        name,
-        ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd"
-    );
+    let dotfile_exact = matches!(name, ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd");
     if dotfile_exact {
         return true;
     }
@@ -292,7 +289,10 @@ fn is_secret_like(path: &Path) -> bool {
         .and_then(|e| e.to_str())
         .map(|e| e.to_ascii_lowercase());
     if let Some(e) = ext.as_deref()
-        && matches!(e, "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore")
+        && matches!(
+            e,
+            "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore"
+        )
     {
         return true;
     }
@@ -530,7 +530,10 @@ mod tests {
             .iter()
             .map(|(p, _)| p.file_name().unwrap().to_string_lossy().into_owned())
             .collect();
-        assert!(rels.iter().any(|p| p == "small.rs"), "small.rs missing: {rels:?}");
+        assert!(
+            rels.iter().any(|p| p == "small.rs"),
+            "small.rs missing: {rels:?}"
+        );
         assert!(
             !rels.iter().any(|p| p == "big.rs"),
             "10 MiB big.rs should have been skipped: {rels:?}"
@@ -557,8 +560,17 @@ mod tests {
                     .replace('\\', "/")
             })
             .collect();
-        assert!(rels.iter().any(|p| p == "src/a.rs"), "src/a.rs missing: {rels:?}");
-        for forbidden in [".env", ".git/config", ".ssh/id_rsa", "keys/server.pem", "keys/server.key"] {
+        assert!(
+            rels.iter().any(|p| p == "src/a.rs"),
+            "src/a.rs missing: {rels:?}"
+        );
+        for forbidden in [
+            ".env",
+            ".git/config",
+            ".ssh/id_rsa",
+            "keys/server.pem",
+            "keys/server.key",
+        ] {
             assert!(
                 !rels.iter().any(|p| p == forbidden),
                 "secret-like path {forbidden} should have been excluded: {rels:?}"

--- a/crates/analyzer-embed/src/scan.rs
+++ b/crates/analyzer-embed/src/scan.rs
@@ -202,7 +202,7 @@ fn load_existing_hashes(
         return Ok(HashMap::new());
     }
     let bytes = fs::read(sidecar_path).context("read sidecar")?;
-    let sidecar = Sidecar::read(&bytes[..])?;
+    let sidecar = Sidecar::from_bytes(&bytes[..])?;
     if sidecar.header.model_id != expected_model_id {
         // Model changed — drop everything, force full rebuild.
         return Ok(HashMap::new());

--- a/crates/analyzer-embed/src/scan.rs
+++ b/crates/analyzer-embed/src/scan.rs
@@ -216,11 +216,19 @@ fn load_existing_hashes(
     Ok(HashMap::new())
 }
 
+/// Maximum size of any single file the embed/slop walkers will read.
+/// Generated or vendored source files can easily balloon past typical
+/// source sizes; reading a multi-hundred-MiB file into memory to hash and
+/// chunk it is almost never what we want. 5 MiB comfortably covers the
+/// legitimate long tail.
+pub(crate) const MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
+
 fn walk_repo(repo: &Path, max_files: usize) -> Result<Vec<(PathBuf, String)>> {
     let mut out = Vec::new();
     for entry in WalkBuilder::new(repo)
         .standard_filters(true)
         .hidden(true)
+        .max_filesize(Some(MAX_FILE_BYTES))
         .build()
     {
         let entry = match entry {
@@ -497,6 +505,36 @@ mod tests {
         };
         let doc = run_scan(&mut embedder, &opts).unwrap();
         assert!(doc.files.contains_key("nested/inner/a.rs"));
+    }
+
+    #[test]
+    fn walk_skips_files_larger_than_cap() {
+        let dir = TempDir::new().unwrap();
+        // Small eligible file - must be kept.
+        {
+            let p = dir.path().join("small.rs");
+            let mut f = File::create(&p).unwrap();
+            f.write_all(b"fn a() {}\n").unwrap();
+        }
+        // 10 MiB file with an eligible extension - must be skipped.
+        {
+            let p = dir.path().join("big.rs");
+            let mut f = File::create(&p).unwrap();
+            let chunk = vec![b'x'; 1024 * 1024];
+            for _ in 0..10 {
+                f.write_all(&chunk).unwrap();
+            }
+        }
+        let files = walk_repo(dir.path(), 100).unwrap();
+        let rels: Vec<String> = files
+            .iter()
+            .map(|(p, _)| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(rels.iter().any(|p| p == "small.rs"), "small.rs missing: {rels:?}");
+        assert!(
+            !rels.iter().any(|p| p == "big.rs"),
+            "10 MiB big.rs should have been skipped: {rels:?}"
+        );
     }
 
     #[test]

--- a/crates/analyzer-embed/src/sidecar.rs
+++ b/crates/analyzer-embed/src/sidecar.rs
@@ -34,6 +34,7 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
 
+use analyzer_core::limits::{MAX_NAME_LEN, MAX_PATH_LEN};
 use anyhow::{Context, Result, anyhow, bail};
 use half::f16;
 use serde::{Deserialize, Serialize};
@@ -51,11 +52,13 @@ const SIDECAR_VERSION: u32 = 1;
 //   - vector_count: BGE-small at per-function × very large monorepo
 //     stays well under 10M.
 //   - dim: BGE-large is 1024; 4096 covers foreseeable future models.
-//   - name_len: paths/symbol names; 1 KiB is already generous.
+//   - name_len / path_len: see analyzer_core::limits. Paths need a larger
+//     cap than symbol names because deeply nested monorepos routinely
+//     exceed 1 KiB on repo-relative paths; we use 4 KiB (PATH_MAX) for
+//     paths and keep the tighter 1 KiB cap for identifiers.
 const MAX_HEADER_LEN: usize = 1 << 20; // 1 MiB
 const MAX_VECTOR_COUNT: usize = 10_000_000;
 const MAX_DIM: usize = 4096;
-const MAX_NAME_LEN: usize = 1024;
 // Minimum bytes required per vector entry (path_len u32 + kind u8 +
 // start u32 + end u32 + name_len u32 + fp16 values). Even with a zero-length
 // path and zero-length name and dim=0 that's at least 17 bytes; we use 17
@@ -339,13 +342,22 @@ fn read_u32<R: Read>(r: &mut R) -> Result<u32> {
     Ok(u32::from_le_bytes(b))
 }
 
+/// Read a length-prefixed UTF-8 string used for repo-relative paths.
+///
+/// Paths can be longer than symbol identifiers in deeply nested
+/// monorepos, so we apply [`MAX_PATH_LEN`] here rather than the tighter
+/// [`MAX_NAME_LEN`].
 fn read_string<R: Read>(r: &mut R) -> Result<String> {
+    read_bounded_string(r, MAX_PATH_LEN, "path")
+}
+
+fn read_bounded_string<R: Read>(r: &mut R, cap: usize, label: &str) -> Result<String> {
     let len = read_u32(r)? as usize;
-    if len > MAX_NAME_LEN {
+    if len > cap {
         return Err(anyhow!(
-            "sidecar string length {} exceeds {} byte cap; file may be corrupt or malicious",
+            "sidecar {label} length {} exceeds {} byte cap; file may be corrupt or malicious",
             len,
-            MAX_NAME_LEN
+            cap,
         ));
     }
     let mut buf = vec![0u8; len];
@@ -517,6 +529,41 @@ mod tests {
             msg.contains("name_len") && msg.contains("cap"),
             "unexpected error: {msg}"
         );
+    }
+
+    #[test]
+    fn oversized_path_len_is_rejected() {
+        // path_len attacker-chosen to MAX_PATH_LEN + 1; we must reject
+        // before attempting to allocate. Pad body past the min-bytes
+        // sanity check so we hit the path_len check and not the earlier
+        // MIN_BYTES_PER_VECTOR floor.
+        let header = br#"{"version":1,"model_id":"m","dim":0,"vector_count":1}"#;
+        let mut buf = craft_header_only(header);
+        buf.extend_from_slice(&((MAX_PATH_LEN + 1) as u32).to_le_bytes()); // path_len
+        buf.extend_from_slice(&[0u8; MIN_BYTES_PER_VECTOR]); // body padding
+        let err = Sidecar::from_bytes(&buf[..]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("path") && msg.contains("cap"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn long_path_under_cap_round_trips() {
+        // Realistic deep-monorepo path: 1500 bytes exceeds MAX_NAME_LEN
+        // (1024) but is well under MAX_PATH_LEN (4096). Before the split
+        // these paths would be rejected as "name_len exceeds cap" during
+        // read. Now they should load fine.
+        let long_path: String = "dir/".repeat(360) + "file.ts"; // ~1447 bytes
+        assert!(long_path.len() > MAX_NAME_LEN);
+        assert!(long_path.len() < MAX_PATH_LEN);
+        let mut a = Sidecar::new("m".into(), 4);
+        a.insert(long_path.clone(), vec![sample_vector()]);
+        let mut out = Vec::new();
+        a.write(&mut out).unwrap();
+        let b = Sidecar::from_bytes(&out[..]).unwrap();
+        assert!(b.vectors.contains_key(&long_path));
     }
 
     #[test]

--- a/crates/analyzer-embed/src/sidecar.rs
+++ b/crates/analyzer-embed/src/sidecar.rs
@@ -34,13 +34,33 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use half::f16;
 use serde::{Deserialize, Serialize};
 
 use crate::chunk::ChunkKind;
 
 const SIDECAR_VERSION: u32 = 1;
+
+// Caps on attacker-controlled length/count fields. A malformed or malicious
+// sidecar could otherwise declare a 4 GiB header or 2^32 vectors and drive
+// the reader into allocating attacker-chosen amounts of memory.
+//
+// Chosen to be comfortably above realistic usage:
+//   - header is small JSON; 1 MiB is ~10x the largest plausible header.
+//   - vector_count: BGE-small at per-function × very large monorepo
+//     stays well under 10M.
+//   - dim: BGE-large is 1024; 4096 covers foreseeable future models.
+//   - name_len: paths/symbol names; 1 KiB is already generous.
+const MAX_HEADER_LEN: usize = 1 << 20; // 1 MiB
+const MAX_VECTOR_COUNT: usize = 10_000_000;
+const MAX_DIM: usize = 4096;
+const MAX_NAME_LEN: usize = 1024;
+// Minimum bytes required per vector entry (path_len u32 + kind u8 +
+// start u32 + end u32 + name_len u32 + fp16 values). Even with a zero-length
+// path and zero-length name and dim=0 that's at least 17 bytes; we use 17
+// as a conservative floor for the implied-size sanity check.
+const MIN_BYTES_PER_VECTOR: usize = 17;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SidecarHeader {
@@ -127,8 +147,47 @@ impl Sidecar {
         self.vectors.insert(path, vectors);
     }
 
+    /// Parse a sidecar from a byte slice. Prefer this over [`Sidecar::read`]
+    /// when reading from an on-disk file because it additionally validates
+    /// the declared vector count against the actual file size to bound
+    /// up-front allocations.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Self::read_inner(bytes, Some(bytes.len()))
+    }
+
+    /// Parse a sidecar from any `Read` source. Applies absolute caps on
+    /// attacker-controlled fields but cannot cross-check against a total
+    /// size - callers with an on-disk file should use [`Sidecar::from_bytes`].
     pub fn read<R: Read>(mut r: R) -> Result<Self> {
+        // Slurp so we can apply the implied-size check consistently. The
+        // caller already had to buffer the header/body to call read_exact
+        // repeatedly, so this doesn't change peak memory by more than a
+        // small constant in the happy path.
+        let mut buf = Vec::new();
+        r.read_to_end(&mut buf).context("read sidecar")?;
+        Self::read_inner(&buf[..], Some(buf.len()))
+    }
+
+    fn read_inner(bytes: &[u8], total_len: Option<usize>) -> Result<Self> {
+        let mut r = bytes;
+
         let header_len = read_u32(&mut r)? as usize;
+        if header_len > MAX_HEADER_LEN {
+            return Err(anyhow!(
+                "sidecar header_len {} exceeds {} byte cap; file may be corrupt or malicious",
+                header_len,
+                MAX_HEADER_LEN
+            ));
+        }
+        if let Some(total) = total_len
+            && header_len.saturating_add(4) > total
+        {
+            return Err(anyhow!(
+                "sidecar header_len {} exceeds available bytes {}",
+                header_len,
+                total
+            ));
+        }
         let mut header_buf = vec![0u8; header_len];
         r.read_exact(&mut header_buf).context("read header")?;
         let header: SidecarHeader =
@@ -140,6 +199,35 @@ impl Sidecar {
                 SIDECAR_VERSION
             );
         }
+        if header.vector_count > MAX_VECTOR_COUNT {
+            return Err(anyhow!(
+                "sidecar vector_count {} exceeds {} cap; file may be corrupt or malicious",
+                header.vector_count,
+                MAX_VECTOR_COUNT
+            ));
+        }
+        if header.dim > MAX_DIM {
+            return Err(anyhow!(
+                "sidecar dim {} exceeds {} cap; file may be corrupt or malicious",
+                header.dim,
+                MAX_DIM
+            ));
+        }
+        // Cross-check declared count against actual bytes left. Each vector
+        // entry requires at least MIN_BYTES_PER_VECTOR + 2*dim bytes.
+        if let Some(total) = total_len {
+            let per_vec = MIN_BYTES_PER_VECTOR.saturating_add(header.dim.saturating_mul(2));
+            let min_body = header.vector_count.saturating_mul(per_vec);
+            let available = total.saturating_sub(4 + header_len);
+            if min_body > available {
+                return Err(anyhow!(
+                    "sidecar declares {} vectors (min {} bytes) but only {} body bytes remain",
+                    header.vector_count,
+                    min_body,
+                    available
+                ));
+            }
+        }
 
         let mut vectors: HashMap<String, Vec<StoredVector>> = HashMap::new();
         for _ in 0..header.vector_count {
@@ -149,6 +237,13 @@ impl Sidecar {
             let start_line = read_u32(&mut r)?;
             let end_line = read_u32(&mut r)?;
             let name_len = read_u32(&mut r)? as usize;
+            if name_len > MAX_NAME_LEN {
+                return Err(anyhow!(
+                    "sidecar name_len {} exceeds {} byte cap; file may be corrupt or malicious",
+                    name_len,
+                    MAX_NAME_LEN
+                ));
+            }
             let name = if name_len == 0 {
                 None
             } else {
@@ -156,6 +251,7 @@ impl Sidecar {
                 r.read_exact(&mut buf).context("read name")?;
                 Some(String::from_utf8(buf).context("name utf-8")?)
             };
+            // header.dim is bounded by MAX_DIM above, so with_capacity is safe.
             let mut values = Vec::with_capacity(header.dim);
             for _ in 0..header.dim {
                 values.push(f16::from_bits(read_u16(&mut r)?));
@@ -245,6 +341,13 @@ fn read_u32<R: Read>(r: &mut R) -> Result<u32> {
 
 fn read_string<R: Read>(r: &mut R) -> Result<String> {
     let len = read_u32(r)? as usize;
+    if len > MAX_NAME_LEN {
+        return Err(anyhow!(
+            "sidecar string length {} exceeds {} byte cap; file may be corrupt or malicious",
+            len,
+            MAX_NAME_LEN
+        ));
+    }
     let mut buf = vec![0u8; len];
     r.read_exact(&mut buf).context("read string bytes")?;
     String::from_utf8(buf).context("string utf-8")
@@ -346,6 +449,87 @@ mod tests {
         let mut buf = Vec::new();
         let err = s.write(&mut buf).unwrap_err();
         assert!(err.to_string().contains("does not match header dim"));
+    }
+
+    /// Build a minimal sidecar byte stream by hand so we can inject
+    /// attacker-controlled length fields without going through Sidecar::write.
+    fn craft_header_only(header_json: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(header_json.len() as u32).to_le_bytes());
+        buf.extend_from_slice(header_json);
+        buf
+    }
+
+    #[test]
+    fn oversized_header_len_is_rejected() {
+        let mut buf = Vec::new();
+        // Declare a 4 GiB - 1 header without supplying the bytes.
+        buf.extend_from_slice(&(u32::MAX).to_le_bytes());
+        let err = Sidecar::from_bytes(&buf[..]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("header_len") && msg.contains("cap"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn oversized_vector_count_is_rejected() {
+        let header = br#"{"version":1,"model_id":"m","dim":4,"vector_count":99999999}"#;
+        let buf = craft_header_only(header);
+        let err = Sidecar::from_bytes(&buf[..]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("vector_count") && msg.contains("cap"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn oversized_dim_is_rejected() {
+        let header = br#"{"version":1,"model_id":"m","dim":999999,"vector_count":0}"#;
+        let buf = craft_header_only(header);
+        let err = Sidecar::from_bytes(&buf[..]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("dim") && msg.contains("cap"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn oversized_name_len_is_rejected() {
+        // Construct: header, then one vector entry with attacker name_len.
+        // path_len=1, path='a', kind=0, start=0, end=0, name_len=MAX+1
+        let header = br#"{"version":1,"model_id":"m","dim":0,"vector_count":1}"#;
+        let mut buf = craft_header_only(header);
+        buf.extend_from_slice(&1u32.to_le_bytes()); // path_len
+        buf.push(b'a'); // path
+        buf.push(0); // kind
+        buf.extend_from_slice(&0u32.to_le_bytes()); // start
+        buf.extend_from_slice(&0u32.to_le_bytes()); // end
+        buf.extend_from_slice(&((MAX_NAME_LEN + 1) as u32).to_le_bytes()); // name_len
+        // We don't add MAX_NAME_LEN+1 bytes - validation must reject before
+        // attempting to allocate.
+        let err = Sidecar::from_bytes(&buf[..]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("name_len") && msg.contains("cap"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn vector_count_mismatched_against_file_size_is_rejected() {
+        // Declares 10M vectors but the body has 0 bytes; must fail fast.
+        let header = br#"{"version":1,"model_id":"m","dim":4,"vector_count":1000000}"#;
+        let buf = craft_header_only(header);
+        let err = Sidecar::from_bytes(&buf[..]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("body bytes remain") || msg.contains("declares"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -27,6 +27,8 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use streaming_iterator::StreamingIterator;
 
+use analyzer_core::limits::MAX_WALK_FILE_SIZE;
+use analyzer_core::secrets::is_secret_like;
 use analyzer_core::types::RepoIntelData;
 
 /// Concrete edit a deslop agent should apply.
@@ -2796,10 +2798,10 @@ fn walk_repo_files(root: &Path) -> Vec<PathBuf> {
     for entry in ignore::WalkBuilder::new(root)
         .standard_filters(true)
         .hidden(true)
-        // Skip files that would need more than 5 MiB of RAM to read; the
-        // slop analyzers read the whole file into memory to parse with
-        // tree-sitter, so unbounded sizes are a DoS vector.
-        .max_filesize(Some(5 * 1024 * 1024))
+        // Skip oversized files — slop analyzers read the whole file into
+        // memory to parse with tree-sitter, so unbounded sizes are a DoS
+        // vector. Cap shared with analyzer-embed via analyzer-core::limits.
+        .max_filesize(Some(MAX_WALK_FILE_SIZE))
         .build()
     {
         let entry = match entry {
@@ -2816,52 +2818,6 @@ fn walk_repo_files(root: &Path) -> Vec<PathBuf> {
         out.push(path.to_path_buf());
     }
     out
-}
-
-/// See crates/analyzer-embed/src/scan.rs for the rationale; kept in sync
-/// here because analyzer-graph does its own repo walk and we don't want
-/// to pull analyzer-embed as a dependency for one helper.
-fn is_secret_like(path: &Path) -> bool {
-    let name = match path.file_name().and_then(|n| n.to_str()) {
-        Some(n) => n,
-        None => return false,
-    };
-    if matches!(name, ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd") {
-        return true;
-    }
-    if name.starts_with(".env.") {
-        return true;
-    }
-    if name.starts_with("id_rsa")
-        || name.starts_with("id_dsa")
-        || name.starts_with("id_ecdsa")
-        || name.starts_with("id_ed25519")
-    {
-        return true;
-    }
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.to_ascii_lowercase());
-    if let Some(e) = ext.as_deref()
-        && matches!(
-            e,
-            "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore"
-        )
-    {
-        return true;
-    }
-    for comp in path.components() {
-        if let Some(c) = comp.as_os_str().to_str()
-            && matches!(
-                c,
-                ".git" | ".ssh" | ".gnupg" | ".aws" | ".gcloud" | ".azure"
-            )
-        {
-            return true;
-        }
-    }
-    false
 }
 
 fn relative(path: &Path, root: &Path) -> String {

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -2797,7 +2797,9 @@ fn walk_repo_files(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     for entry in ignore::WalkBuilder::new(root)
         .standard_filters(true)
-        .hidden(true)
+        // Keep hidden files in — `tracked_artifacts` needs to see `.DS_Store`,
+        // `.swp`, etc. Secret-like paths are filtered below by `is_secret_like`.
+        .hidden(false)
         // Skip oversized files — slop analyzers read the whole file into
         // memory to parse with tree-sitter, so unbounded sizes are a DoS
         // vector. Cap shared with analyzer-embed via analyzer-core::limits.

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -2826,10 +2826,7 @@ fn is_secret_like(path: &Path) -> bool {
         Some(n) => n,
         None => return false,
     };
-    if matches!(
-        name,
-        ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd"
-    ) {
+    if matches!(name, ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd") {
         return true;
     }
     if name.starts_with(".env.") {
@@ -2847,7 +2844,10 @@ fn is_secret_like(path: &Path) -> bool {
         .and_then(|e| e.to_str())
         .map(|e| e.to_ascii_lowercase());
     if let Some(e) = ext.as_deref()
-        && matches!(e, "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore")
+        && matches!(
+            e,
+            "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore"
+        )
     {
         return true;
     }

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -2795,18 +2795,69 @@ fn walk_repo_files(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     for entry in ignore::WalkBuilder::new(root)
         .standard_filters(true)
-        .hidden(false)
+        .hidden(true)
         .build()
     {
         let entry = match entry {
             Ok(e) => e,
             Err(_) => continue,
         };
-        if entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
-            out.push(entry.path().to_path_buf());
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
         }
+        let path = entry.path();
+        if is_secret_like(path) {
+            continue;
+        }
+        out.push(path.to_path_buf());
     }
     out
+}
+
+/// See crates/analyzer-embed/src/scan.rs for the rationale; kept in sync
+/// here because analyzer-graph does its own repo walk and we don't want
+/// to pull analyzer-embed as a dependency for one helper.
+fn is_secret_like(path: &Path) -> bool {
+    let name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(n) => n,
+        None => return false,
+    };
+    if matches!(
+        name,
+        ".env" | ".npmrc" | ".pypirc" | ".netrc" | ".htpasswd"
+    ) {
+        return true;
+    }
+    if name.starts_with(".env.") {
+        return true;
+    }
+    if name.starts_with("id_rsa")
+        || name.starts_with("id_dsa")
+        || name.starts_with("id_ecdsa")
+        || name.starts_with("id_ed25519")
+    {
+        return true;
+    }
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    if let Some(e) = ext.as_deref()
+        && matches!(e, "pem" | "key" | "crt" | "p12" | "pfx" | "jks" | "keystore")
+    {
+        return true;
+    }
+    for comp in path.components() {
+        if let Some(c) = comp.as_os_str().to_str()
+            && matches!(
+                c,
+                ".git" | ".ssh" | ".gnupg" | ".aws" | ".gcloud" | ".azure"
+            )
+        {
+            return true;
+        }
+    }
+    false
 }
 
 fn relative(path: &Path, root: &Path) -> String {

--- a/crates/analyzer-graph/src/slop.rs
+++ b/crates/analyzer-graph/src/slop.rs
@@ -2796,6 +2796,10 @@ fn walk_repo_files(root: &Path) -> Vec<PathBuf> {
     for entry in ignore::WalkBuilder::new(root)
         .standard_filters(true)
         .hidden(true)
+        // Skip files that would need more than 5 MiB of RAM to read; the
+        // slop analyzers read the whole file into memory to parse with
+        // tree-sitter, so unbounded sizes are a DoS vector.
+        .max_filesize(Some(5 * 1024 * 1024))
         .build()
     {
         let entry = match entry {

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,80 @@
+# cargo-deny configuration for agent-analyzer.
+#
+# Run locally with:
+#   cargo install cargo-deny --locked
+#   cargo deny check
+#
+# CI integration is a follow-up; this file establishes the policy.
+
+[graph]
+all-features = false
+no-default-features = false
+
+[output]
+feature-depth = 1
+
+# ── Advisories ────────────────────────────────────────────────────────
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# Any known CVE in the dep tree fails the build.
+yanked = "deny"
+# Unmaintained crates warn but don't fail; they're often unavoidable in
+# transitive deps and we want signal, not noise.
+ignore = []
+
+# ── Licenses ──────────────────────────────────────────────────────────
+[licenses]
+version = 2
+# Permissive licenses we accept.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+    "0BSD",
+]
+confidence-threshold = 0.93
+# Strong-copyleft licenses are not compatible with the MIT license on
+# the workspace; deny them explicitly so a new transitive dep under
+# GPL/AGPL/SSPL fails the build instead of quietly shipping.
+exceptions = []
+
+# Deny these license IDs outright even if somehow detected as compatible.
+[[licenses.clarify]]
+# ring has a bespoke license expression; map it to the common form.
+name = "ring"
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# ── Bans ──────────────────────────────────────────────────────────────
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+highlight = "all"
+# Deny specific crates if they show up - placeholder list; extend when
+# a concrete risk is identified.
+deny = []
+# Skip known-duplicate-version noise from the ecosystem.
+skip = []
+skip-tree = []
+
+# ── Sources ───────────────────────────────────────────────────────────
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# Only allow git deps from the agent-sh org. Add other trusted orgs here
+# explicitly if needed.
+allow-git = []
+
+[sources.allow-org]
+github = ["agent-sh"]


### PR DESCRIPTION
## Summary

Security hardening from an internal audit (2026-04-26). 5 commits, each a single concern:

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | HIGH | Sidecar parser allocates up to 4 GiB from attacker-controlled u32 lengths (OOM + `panic = abort`) | Cap header_len (1 MiB), vector_count (10M), dim (4096), name_len (1 KiB); 5 reject-path tests |
| 2 | HIGH | No release attestation — only SHA256 sidecars | Publish SLSA build-provenance via \`actions/attest-build-provenance\` |
| 3 | MED | Embed/slop walkers include hidden files (\`.env\`, \`.git/\`, \`.ssh/\`, keys) | \`.hidden(true)\` + is_secret_like deny patterns |
| 4 | MED | No per-file size cap before embedding | \`max_filesize(5 MiB)\` on both walkers |
| 5 | MED | No cargo-deny config | Add \`deny.toml\` (advisories/licenses/bans/sources) |

## Test plan

- \`cargo test -p analyzer-embed\`: 35 unit + 4 integration, all pass
- \`cargo build --release\`: clean
- \`cargo deny check\`: all categories clean

## Follow-ups (separate issues)

- Client-side attestation verification in \`agent-core\`'s \`lib/binary/index.js\`
- Add \`cargo deny check\` CI job (\`EmbarkStudios/cargo-deny-action\`)
- Deduplicate \`is_secret_like\` between analyzer-embed and analyzer-graph

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes low-level sidecar parsing and repo file discovery (hidden/large/secret-like files now skipped), which could affect embedding/analyzer coverage, and it alters release workflow permissions/steps for attestations.
> 
> **Overview**
> Adds security hardening across artifact parsing, repo walking, and releases.
> 
> The sidecar (`repo-intel.embeddings.bin`) reader now enforces strict caps and size cross-checks (header length, vector count, dim, string lengths) via `Sidecar::from_bytes`, with new tests to ensure malformed sidecars fail fast instead of causing OOM/panic.
> 
> Repo walkers used by embedding and slop analysis now *exclude hidden paths*, skip secret-like filenames/extensions/directories, and apply a 5 MiB per-file size cap (with new `scan.rs` tests).
> 
> The release workflow now publishes SLSA build-provenance attestations for per-target archives (OIDC `id-token`/`attestations` permissions, pinned `actions/attest-build-provenance`), and the repo adds a baseline `deny.toml` policy for `cargo-deny` (advisories/licenses/sources).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6dc5198d003fcf6def64052c563a973ebd49cb6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->