### PR TITLE
ci: add cargo-deny workflow

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,20 @@
+name: cargo-deny
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  cargo-deny:
+    name: cargo-deny check
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      # EmbarkStudios/cargo-deny-action@v2.0.17
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb
+        with:
+          log-level: warn
+          command: check
+          arguments: --all-features

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [main]
 
+# Minimal permissions — cargo-deny only needs to read the repo.
+# Matches the pattern used by ci.yml and release.yml. Hardening per
+# CodeQL + cursor review on #38.
+permissions:
+  contents: read
+
 jobs:
   cargo-deny:
     name: cargo-deny check


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deny.yml` running `cargo deny check --all-features` on pull_request and push to main
- Uses the existing `deny.toml` introduced in v0.8.0 (#37); no policy changes
- Actions pinned by commit SHA (v6.0.2 checkout, v2.0.17 cargo-deny-action)

## Why

`deny.toml` landed in #37 with a comment noting "CI integration is a follow-up; this file establishes the policy". This PR closes that follow-up so the policy is actually enforced.

## Test plan

- [ ] Workflow runs green on this PR (validates current advisory/license/source state)
- [ ] Future dep bumps that introduce a CVE or banned license break CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a GitHub Actions workflow that runs `cargo deny check` and does not change application code or dependency policy itself.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `deny.yml`, that runs `cargo deny check --all-features` on pull requests and pushes to `main` to enforce the existing `deny.toml` advisory/license/source policy in CI.
> 
> The workflow uses pinned SHAs for `actions/checkout` and `EmbarkStudios/cargo-deny-action` and logs at `warn` level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1f03cf3681f5ee726ab1ec827cc54ab312a053. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->