### PR TITLE
fix(deps): bump openssl to 0.10.80 (security)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,15 +2068,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2115,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Resolves 3 open Dependabot alerts against the `openssl` crate (`< 0.10.80`): 1 high, 2 medium.

- `openssl` 0.10.78 -> 0.10.80
- `openssl-sys` 0.9.114 -> 0.9.116 (transitive)

Lockfile-only. `cargo build` + `cargo test` pass locally.