### PR TITLE
ci(security): pin 3rd-party actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,18 +65,18 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}
           save-if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install cross
         if: matrix.cross
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2 # v2
         with:
           tool: cross@0.2.5
 
@@ -241,7 +241,7 @@ jobs:
           echo "Release $VERSION" > release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: ${{ steps.notes.outputs.version }}
           body_path: release_notes.md


### PR DESCRIPTION
Resolves the CodeQL `actions/unpinned-tag` alerts. Pins third-party actions in `ci.yml` and `release.yml` to full commit SHAs (version kept in a trailing comment):

- `dtolnay/rust-toolchain@stable` -> `@29eef33` # stable
- `Swatinem/rust-cache@v2` -> `@e18b497` # v2
- `taiki-e/install-action@v2` -> `@0fd4636` # v2
- `softprops/action-gh-release@v2` -> `@3bb1273` # v2

A moved tag can no longer silently change the action that runs. YAML validated.